### PR TITLE
Fix contract CI

### DIFF
--- a/packages/contract/foundry.toml
+++ b/packages/contract/foundry.toml
@@ -2,5 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+solc = "0.8.19"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Foundry nightly switches underlying `solc` compiler which changes `CREATE2` input (and output), breaking our test