### PR TITLE
Ephemeral Notes contract

### DIFF
--- a/packages/contract/src/EphemeralNotes.sol
+++ b/packages/contract/src/EphemeralNotes.sol
@@ -10,6 +10,13 @@ struct Note {
     uint256 amount;
 }
 
+/**
+ * @title EphemeralNotes
+ * @notice Simple escrow notes, used for onboarding new accounts.
+ * Notes are created by a user and can be redeemed by anyone who shows
+ * a signature from the ephemeral key owner for their address. Additionally,
+ * the sender of the note can "revert" it without a signature.
+ */
 contract EphemeralNotes {
   mapping(address => Note) public notes;
   IERC20 public immutable token;
@@ -28,6 +35,8 @@ contract EphemeralNotes {
     uint256 _amount
   ) external {
     require(notes[_ephemeralOwner].ephemeralOwner == address(0), "EphemeralNotes: note already exists");
+    require(_ephemeralOwner != address(0));
+    require(_amount > 0);
 
     notes[_ephemeralOwner] = Note({
       ephemeralOwner: _ephemeralOwner,
@@ -39,6 +48,7 @@ contract EphemeralNotes {
     token.transferFrom(msg.sender, address(this), _amount);
   }
 
+  // Either the recipient (with a valid signature) or the sender can redeem the note
   function claimNote(
     address _ephemeralOwner,
     bytes memory _signature

--- a/packages/contract/src/EphemeralNotes.sol
+++ b/packages/contract/src/EphemeralNotes.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.12;
+
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+
+struct Note {
+    address ephemeralOwner;
+    address from;
+    uint256 amount;
+}
+
+contract EphemeralNotes {
+  mapping(address => Note) public notes;
+  IERC20 public immutable token;
+  
+  event NoteCreated(Note note);
+  event NoteRedeemed(Note note);
+
+  constructor(IERC20 _token) {
+    token = _token;
+  }
+
+
+  // Call token.approve(<address of this contract>, amount) on the token contract before this
+  function createNote(
+    address _ephemeralOwner,
+    uint256 _amount
+  ) external {
+    require(notes[_ephemeralOwner].ephemeralOwner == address(0), "EphemeralNotes: note already exists");
+
+    notes[_ephemeralOwner] = Note({
+      ephemeralOwner: _ephemeralOwner,
+      from: msg.sender,
+      amount: _amount
+    });
+
+    emit NoteCreated(notes[_ephemeralOwner]);
+    token.transferFrom(msg.sender, address(this), _amount);
+  }
+
+  function claimNote(
+    address _ephemeralOwner,
+    bytes memory _signature
+  ) external {
+    Note memory note = notes[_ephemeralOwner];
+    require(note.ephemeralOwner != address(0), "EphemeralNotes: note does not exist");
+
+    bytes32 message = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(msg.sender)));
+    address signer = ECDSA.recover(message, _signature);
+    require(signer == _ephemeralOwner || msg.sender == note.from, "EphemeralNotes: invalid signature and not creator");
+
+    emit NoteRedeemed(note);
+    delete notes[_ephemeralOwner];
+    token.transfer(msg.sender, note.amount);
+  }
+}

--- a/packages/contract/test/EphemeralNotes.t.sol
+++ b/packages/contract/test/EphemeralNotes.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import "../src/EphemeralNotes.sol";
+
+contract TestDAI is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}
+
+contract EphemeralNotesTest is Test {
+    TestDAI public token;
+    EphemeralNotes public notes;
+    uint256 private constant ephemeralPrivateKey = 0x1010101010101010101010101010101010101010101010101010101010101010;
+    address private ephemeralAddress = vm.addr(ephemeralPrivateKey);
+    address constant ALICE = address(0x123);
+    address constant BOB = address(0x456);
+
+    event NoteCreated(Note note);
+    event NoteRedeemed(Note note);
+
+    function setUp() public {
+        token = new TestDAI("TestDAI", "DAI");
+        notes = new EphemeralNotes(token);
+    }
+
+    // This is equivalent to what the users have to run on client side using ethers.js or equivalent
+    function createEphemeralSignature(address redeemer) pure internal returns (bytes memory) {
+        bytes32 messageHash = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(redeemer)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ephemeralPrivateKey, messageHash);
+
+        bytes memory signature = abi.encodePacked(r, s, v);
+        return signature;
+    }
+
+    function testECDSA() public {
+        bytes32 messageHash = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(ALICE)));
+        assertTrue(ECDSA.recover(messageHash, createEphemeralSignature(ALICE)) == ephemeralAddress);
+    }
+
+    function createAliceNote() internal {
+        token.mint(ALICE, 1000);
+
+        vm.startPrank(ALICE, ALICE);
+        token.approve(address(notes), 501);
+        notes.createNote(ephemeralAddress, 500);
+        vm.stopPrank();
+    }
+
+    function testRegularFlow() public {
+        // Alice approves token contract and creates a new note to ephemeralAddress
+        createAliceNote();
+
+        // Bob uses ephemeralAddress to sign his own address and redeem the note
+        vm.startPrank(BOB, BOB);
+        notes.claimNote(ephemeralAddress, createEphemeralSignature(BOB));
+        vm.stopPrank();
+
+        // Check transfer went through correctly
+        assertEq(token.balanceOf(ALICE), 500);
+        assertEq(token.balanceOf(BOB), 500);
+        assertEq(token.balanceOf(address(notes)), 0);
+    }
+
+    function testFailingFlow() public {
+        // Alice approves token contract and creates a new note to ephemeralAddress
+        createAliceNote();
+
+        // Bob uses ephemeralAddress to sign wrong address and redeem the note
+        vm.startPrank(BOB, BOB);
+        notes.claimNote(ephemeralAddress, createEphemeralSignature(address(0x789)));
+        vm.stopPrank();
+
+        // Check transfer failed
+        assertEq(token.balanceOf(ALICE), 500);
+        assertEq(token.balanceOf(BOB), 0);
+        assertEq(token.balanceOf(address(notes)), 500);
+    }
+
+    function testRevertFlow() public {
+        // Alice approves token contract and creates a new note to ephemeralAddress
+        createAliceNote();
+
+        // Alice short circuits and reverts the note to herself
+        // She does not need a valid signature from ephemeralAddress to do this
+        vm.startPrank(ALICE, ALICE);
+        notes.claimNote(ephemeralAddress, createEphemeralSignature(BOB));
+        vm.stopPrank();
+
+        // Check transfer went through correctly
+        assertEq(token.balanceOf(ALICE), 1000);
+        assertEq(token.balanceOf(address(notes)), 0);
+    }
+}

--- a/packages/contract/test/EphemeralNotes.t.sol
+++ b/packages/contract/test/EphemeralNotes.t.sol
@@ -69,12 +69,13 @@ contract EphemeralNotesTest is Test {
         assertEq(token.balanceOf(address(notes)), 0);
     }
 
-    function testFailingFlow() public {
+    function testWrongFlow() public {
         // Alice approves token contract and creates a new note to ephemeralAddress
         createAliceNote();
 
         // Bob uses ephemeralAddress to sign wrong address and redeem the note
         vm.startPrank(BOB, BOB);
+        vm.expectRevert("EphemeralNotes: invalid signature and not creator");
         notes.claimNote(ephemeralAddress, createEphemeralSignature(address(0x789)));
         vm.stopPrank();
 


### PR DESCRIPTION
On-chain, anyone who can show up with a signature of their address from the ephemeral (regular ECDSA) keypair can claim the note. Separately, the sender themselves can always claim the note (even without a signature), that way the sender can sweep old notes even if they lose the private keys themselves.

Off-chain, the expected flow is that the sender will send the private key (as part of the temp URL) to the receiver.