### PR TITLE
Dev quick start, use remote API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,14 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "json.schemas": [
+    {
+      "fileMatch": ["eas.json"],
+      "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The mission is to make an excellent experience. Payments should be fast, secure,
 
 ### Development
 
+**Daimo is under active development.** Coming soon to testnet and TestFlight.
+
+<details>
+<summary><strong>Quick start for developers</strong></summary>
+
 You'll need Node 20 and recent Xcode. Clone the repo, loading submodules.
 
 ```
@@ -23,7 +28,7 @@ git clone git@github.com:daimo-eth/daimo --recurse-submodules
 Install prerequisites.
 
 ```
-# Install Foundry, if you haven't yet.
+# Install Foundry
 curl -L https://foundry.paradigm.xyz | bash
 # Reload your terminal, then run:
 foundryup
@@ -41,8 +46,19 @@ npm i
 npm run build
 ```
 
+Configure the API.
+- To run the API locally, configure the `DAIMO_API_*` env vars.
+- To use the testnet staging API, set `DAIMO_APP_API_URL=https://daimo-api-stage.onrender.com`.
+
 Finally, run the app in the iOS simulator.
+
+If you're in the <a href="https://expo.dev/accounts/daimo">Daimo team on Expo</a>, you can download the latest base build from there.
+
+> Expo apps come in two layers: a native layer and a React Native (typescript) layer. Whenever you add a native module or update `@daimo/expo-enclave`, you must rebuild the native app. For details, see the `@daimo/mobile` package.
+
+Once the base app is installed in your simulator, you can run Daimo:
 
 ```
 npm start
 ```
+</details>

--- a/apps/daimo-mobile/babel.config.js
+++ b/apps/daimo-mobile/babel.config.js
@@ -3,5 +3,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
+    plugins: ["transform-inline-environment-variables"],
   };
 };

--- a/apps/daimo-mobile/eas.json
+++ b/apps/daimo-mobile/eas.json
@@ -24,6 +24,9 @@
       "distribution": "internal",
       "ios": {
         "resourceClass": "m-medium"
+      },
+      "env": {
+        "DAIMO_APP_API_URL": "https://daimo-api-stage.onrender.com"
       }
     },
     "production": {

--- a/apps/daimo-mobile/package.json
+++ b/apps/daimo-mobile/package.json
@@ -10,8 +10,8 @@
     "build:prod": "eas build -p all",
     "start": "expo start --dev-client -i",
     "start:tunnel": "expo start --dev-client --tunnel",
-    "start:android": "expo run:android",
-    "start:ios": "expo run:ios",
+    "run:android": "expo run:android",
+    "run:ios": "expo run:ios",
     "test": "tsc --noEmit && jest",
     "lint": "npm run lint:deps && npm run lint:style",
     "lint:deps": "ts-unused-exports ./tsconfig.json --excludePathsFromReport=gen '--ignoreFiles=.*.config.ts' && npx depcheck --ignores @expo/ngrok,@types/jest,expo-dev-client,expo-splash-screen,expo-build-properties,@babel/core",
@@ -35,7 +35,7 @@
     "depcheck": "^1.4.3",
     "eslint": "^8.38.0",
     "eslint-config-universe": "^11.2.0",
-    "expo": "~48.0.15",
+    "expo": "~48.0.18",
     "expo-barcode-scanner": "^12.3.2",
     "expo-build-properties": "~0.6.0",
     "expo-clipboard": "^4.1.2",
@@ -99,5 +99,8 @@
         }
       ]
     }
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
   }
 }

--- a/apps/daimo-mobile/package.json
+++ b/apps/daimo-mobile/package.json
@@ -14,7 +14,7 @@
     "run:ios": "expo run:ios",
     "test": "tsc --noEmit && jest",
     "lint": "npm run lint:deps && npm run lint:style",
-    "lint:deps": "ts-unused-exports ./tsconfig.json --excludePathsFromReport=gen '--ignoreFiles=.*.config.ts' && npx depcheck --ignores @expo/ngrok,@types/jest,expo-dev-client,expo-splash-screen,expo-build-properties,@babel/core",
+    "lint:deps": "ts-unused-exports ./tsconfig.json --excludePathsFromReport=gen '--ignoreFiles=.*.config.ts' && npx depcheck --ignores @expo/ngrok,@types/jest,expo-dev-client,expo-splash-screen,expo-build-properties,@babel/core,babel-plugin-transform-inline-environment-variables",
     "lint:style": "eslint .",
     "fix:deps": "expo install --fix",
     "fix:style": "eslint --fix ."
@@ -101,6 +101,7 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.20.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.4"
   }
 }

--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -11,6 +11,7 @@ import { useAccount } from "./logic/account";
 import { Chain, ChainContext, ChainStatus, ViemChain } from "./logic/chain";
 import { trpc } from "./logic/trpc";
 import { HomeStackNav } from "./view/HomeStack";
+import { env } from "./logic/env";
 
 export default function App() {
   console.log("[APP] rendering\n\n");
@@ -33,7 +34,7 @@ export default function App() {
     trpc.createClient({
       links: [
         httpBatchLink({
-          url: "http://localhost:3000",
+          url: env.apiUrl,
           fetch: (input: RequestInfo | URL, init?: RequestInit) => {
             console.log(`[APP] trpc fetching ${input}`);
             return fetch(input, init);

--- a/apps/daimo-mobile/src/logic/env.ts
+++ b/apps/daimo-mobile/src/logic/env.ts
@@ -1,0 +1,7 @@
+export const env = {
+  apiUrl: process.env.DAIMO_APP_API_URL || "http://localhost:3000",
+  buildProfile: process.env.EAS_BUILD_PROFILE || "local",
+  gitHash: (process.env.EAS_BUILD_GIT_COMMIT_HASH || "unknown").substring(0, 8),
+};
+
+console.log(`environment ${JSON.stringify(env, null, 2)}`);

--- a/apps/daimo-mobile/src/view/screen/UserScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/UserScreen.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from "react";
-import { Button, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 
 import { useAccount } from "../../logic/account";
+import { env } from "../../logic/env";
+import { ButtonMed } from "../shared/Button";
 import { useNav } from "../shared/nav";
 import { color, ss } from "../shared/style";
+import { TextBold, TextSmall } from "../shared/text";
 import { timeAgo, useTime } from "../shared/time";
 
 export function UserScreen() {
@@ -27,7 +30,19 @@ export function UserScreen() {
         <Text style={ss.text.body}>
           As of {timeAgo(account.lastBlockTimestamp, nowS)}
         </Text>
-        <Button title="Clear wallet" onPress={() => setAccount(null)} />
+        <ButtonMed
+          type="danger"
+          title="Clear wallet"
+          onPress={() => setAccount(null)}
+        />
+
+        <View style={ss.spacer.h64} />
+        <TextSmall>
+          Build <TextBold>{env.gitHash}</TextBold>
+        </TextSmall>
+        <TextSmall>
+          Profile <TextBold>{env.buildProfile}</TextBold>
+        </TextSmall>
       </View>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "depcheck": "^1.4.3",
         "eslint": "^8.38.0",
         "eslint-config-universe": "^11.2.0",
-        "expo": "~48.0.15",
+        "expo": "~48.0.18",
         "expo-barcode-scanner": "^12.3.2",
         "expo-build-properties": "~0.6.0",
         "expo-clipboard": "^4.1.2",
@@ -66,12 +66,16 @@
         "typescript": "^5.1.3",
         "viem": "^0.3.18",
         "wagmi": "^1.1.1"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.20.0"
       }
     },
     "apps/daimo-testbed": {
       "name": "@daimo/testbed",
       "version": "1.0.0",
       "dependencies": {
+        "@daimo/contract": "*",
         "@daimo/expo-enclave": "*",
         "@daimo/userop": "*",
         "@ethersproject/shims": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
         "wagmi": "^1.1.1"
       },
       "devDependencies": {
-        "@babel/core": "^7.20.0"
+        "@babel/core": "^7.20.0",
+        "babel-plugin-transform-inline-environment-variables": "^0.4.4"
       }
     },
     "apps/daimo-testbed": {
@@ -11505,6 +11506,12 @@
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "node_modules/babel-plugin-transform-inline-environment-variables": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.4.tgz",
+      "integrity": "sha512-bJILBtn5a11SmtR2j/3mBOjX4K3weC6cq+NNZ7hG22wCAqpc3qtj/iN7dSe9HDiS46lgp1nHsQgeYrea/RUe+g==",
+      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "eslintConfig": {
     "extends": "universe/node",
     "ignorePatterns": [
-      "dist",
-      "gen"
+      "dist"
     ],
     "rules": {
       "import/order": [

--- a/packages/daimo-api/src/index.ts
+++ b/packages/daimo-api/src/index.ts
@@ -14,6 +14,7 @@ export type AppRouter = ReturnType<typeof createRouter>;
 async function main() {
   console.log(`[API] starting...`);
   const walletClient = getEnvWalletClient();
+  console.log(`[API] using wallet ${walletClient.account.address}`);
   const nameReg = new NameRegistry(walletClient);
   const faucet = new Faucet(walletClient);
   const accountFactory = new AccountFactory(walletClient);

--- a/packages/daimo-contract/package.json
+++ b/packages/daimo-contract/package.json
@@ -6,8 +6,7 @@
   "main": "./dist/generated.js",
   "scripts": {
     "codegen": "wagmi generate",
-    "build": "tsc",
-    "lint": "eslint ."
+    "build": "tsc"
   },
   "author": "",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION

- Quick start instructions in README
- Certain env vars inlined into compiled app. See `env.ts`
- API URL no longer hardcoded. `DAIMO_APP_API_URL` still defaults to `locahost:3000`
- You can point it to `https://daimo-api-stage.onrender.com` to use deployed staging API