### PR TITLE
Websocket transport

### DIFF
--- a/apps/daimo-mobile/package.json
+++ b/apps/daimo-mobile/package.json
@@ -9,7 +9,6 @@
     "build:stage": "eas build -p ios --profile=stage",
     "submit:stage": "eas submit --platform ios --profile=stage",
     "start": "expo start --dev-client --clear -i",
-    "start:tunnel": "expo start --dev-client --tunnel",
     "run:android": "expo run:android",
     "run:ios": "expo run:ios",
     "test": "tsc --noEmit && jest",

--- a/apps/daimo-mobile/src/logic/chain.ts
+++ b/apps/daimo-mobile/src/logic/chain.ts
@@ -6,6 +6,7 @@ import {
   createPublicClient,
   getContract,
   http,
+  webSocket,
 } from "viem";
 import { baseGoerli, goerli } from "viem/chains";
 import { erc20ABI } from "wagmi";
@@ -56,8 +57,7 @@ export class Chain implements Chain {
 
   clientL2 = createPublicClient({
     chain: chainConfig.l2,
-    transport: http(),
-    // TODO: webSocket("wss://base-goerli.public.blastapi.io")
+    transport: webSocket("wss://base-goerli.public.blastapi.io"),
     // See bug https://github.com/wagmi-dev/viem/issues/711
   });
 


### PR DESCRIPTION
## Use websocket transport

This should speed up onchain lookups.


## Do we need local chain RPC at all?

An alternative would be to route everything through the Daimo API.

- Make the Daimo API pluggable and (eventually) trust-minimized
- Connect via websocket for efficient event subscriptions
- Make it relatively easy for other parties to run performant API servers
- Stretch goal: app ships with at least two independent API endpoints. Advanced setting to add or change. App tracks performance of each endpoint, sends traffic to the ones that are available & fastest. This serves both performance and censorship resistance.
- End goal: app ships with a light client (probably `helios`). The API server is temporarily trusted for fast transaction confirmation, but verified via light client proofs.