### PR TITLE
Recipient Confirmation Codes

### DIFF
--- a/packages/contract/script/DemoExec.s.sol
+++ b/packages/contract/script/DemoExec.s.sol
@@ -18,6 +18,7 @@ contract DemoExecScript is Script {
         newAcc.execute(
             0xF05b5f04B7a77Ca549C0dE06beaF257f40C66FDB,
             0.01 ether,
+            0x0,
             data
         );
 

--- a/packages/daimo-userop/src/index.ts
+++ b/packages/daimo-userop/src/index.ts
@@ -124,7 +124,8 @@ export class DaimoAccount {
   /** Sends an ERC20 transfer. Returns userOpHash. */
   public async erc20transfer(
     to: Address,
-    amount: `${number}` // in the native unit of the token
+    amount: `${number}`, // in the native unit of the token,
+    confirmation_code: byte[2] // 4 hex digits
   ): Promise<UserOpHandle> {
     const parsedAmount = parseUnits(amount, this.tokenDecimals);
     console.log(`[OP] transfer ${parsedAmount} ${this.tokenAddress} to ${to}`);


### PR DESCRIPTION
This is only a high-level feature proposal and not a functioning branch atm; I just wanted to include a bit of code as a rough illustration.

## Summary
When you send a Venmo payment to an unknown recipient, you get prompted to enter the last 4 digits of their phone number as an optional way of confirming it's the right person. A simple way to provide a similar experience (if paired with the right UX) would be to define a recipient's "confirmation code" to be the last 4 or so hex digits of the hash of their wallet address, and use it in the same way.

You could have the app frontend just derive the code on the fly from the recipient address that the user inputs, but then using it would be completely contrived and wouldn't prevent any mistakes. Thus, the way I imagine UX working is that in the frontend, you'd omit the logic for deriving confirmation codes for anyone except the user's own wallet address, which they could then share along with their address/ENS name when receiving a payment.

Of course, doing this check on a tx locally before prompting for a signature, rather than afterwards on-chain, would probably be just as good, but thanks to account abstraction this is pretty painless to implement on the smart contract side—I wrote out a quick sketch of what that would look like.

While ENS domains and QR codes are definitely the most important things, I would personally quite like having a light optional guardrail like this as well, and I think it would help prevent mistakes even in a world with ubiquitous ENS usage (w.r.t. domain name lookalikes, for example). For me it takes away the anxiety when I'm entering a recipient manually—it's a way to feel basically certain that I've entered the recipient correctly that isn't just looking really closely at what I've just entered, which imo isn't the greatest, even when the addresses are human-readable.

Keen for some feedback on this idea—if you all were on board, I might take some time to prototype a frontend integration, or move it over there entirely.