### PR TITLE
Debug log test

### DIFF
--- a/apps/daimo-mobile/test/log.test.ts
+++ b/apps/daimo-mobile/test/log.test.ts
@@ -1,0 +1,46 @@
+import { getDebugLog, initDebugLog } from "../src/debugLog";
+
+describe("debugLog", () => {
+  initDebugLog();
+
+  const getLines = () =>
+    getDebugLog()
+      .replace(/^2[^ ]*Z /gm, "")
+      .split("\n");
+
+  it("records console logs", () => {
+    console.log("hello");
+    console.warn("world");
+    console.error("error");
+
+    expect(getLines()).toStrictEqual([
+      "log hello",
+      "WRN world",
+      "ERR error",
+      "- debug log captured",
+    ]);
+  });
+
+  it("handles JSON and non-JSON objects", () => {
+    console.log("a", { a: 1 });
+    console.log("b", 123n);
+    const circular = {} as any;
+    circular["circular"] = circular;
+    console.log("c", circular);
+
+    expect(getLines().slice(3)).toStrictEqual([
+      'log a {"a":1}',
+      "log b 123",
+      "log c [object Object]",
+      "- debug log captured",
+    ]);
+  });
+
+  it("handles errors", () => {
+    console.error(new Error("test"));
+    const lines = getLines().slice(6);
+
+    expect(lines[0]).toBe("ERR Error: test");
+    expect(lines[1]).toMatch(/at Object\.<anonymous> \(.*\/log.test.ts/);
+  });
+});


### PR DESCRIPTION
Now supports console.`log`/`warn`/`error`

- Includes error stacktrace, if available
- Truncates very long lines
- Added unit test