### PR TITLE
fix: onboarding Allow Notifications, pending op for faucet & notes

### DIFF
--- a/apps/daimo-mobile/app.json
+++ b/apps/daimo-mobile/app.json
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "eth.daimo",
-      "buildNumber": "25",
+      "buildNumber": "27",
       "associatedDomains": [
         "applinks:daimo.onrender.com"
       ],

--- a/apps/daimo-mobile/src/sync/recipients.ts
+++ b/apps/daimo-mobile/src/sync/recipients.ts
@@ -43,6 +43,10 @@ export function useRecipientSearch(prefix: string) {
     if (recentsByAddr.has(other)) continue;
 
     const acc = getCachedEAccount(other);
+    // Hack: don't show Note contract as a recipient
+    // TODO: show note claimer as recipient.
+    if (acc.label === "note") continue;
+
     const r: Recipient = { ...acc, lastSendTime: t.timestamp };
 
     recents.push(r);

--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -22,7 +22,7 @@ import { ButtonMed, ButtonSmall } from "../shared/Button";
 import Spacer from "../shared/Spacer";
 import { useNav } from "../shared/nav";
 import { color, ss } from "../shared/style";
-import { TextBody, TextBold, TextH2, TextH3, TextLight } from "../shared/text";
+import { TextBody, TextBold, TextH2, TextLight } from "../shared/text";
 
 export function AccountScreen() {
   const [account, setAccount] = useAccount();
@@ -72,9 +72,7 @@ export function AccountScreen() {
       <ScrollView contentContainerStyle={ss.container.vertModal}>
         <Spacer h={8} />
         <View style={ss.container.ph16}>
-          <TextH2>Account</TextH2>
-          <Spacer h={16} />
-          <TextH3>{account.name}</TextH3>
+          <TextH2>{account.name}</TextH2>
         </View>
         <ButtonSmall onPress={linkToExplorer}>
           <View>
@@ -87,7 +85,11 @@ export function AccountScreen() {
             </TextLight>
           </View>
         </ButtonSmall>
-        <Spacer h={16} />
+        <Spacer h={32} />
+        <View style={ss.container.ph16}>
+          <TextH2>Devices</TextH2>
+        </View>
+        <Spacer h={8} />
         <View style={styles.callout}>
           <TextBody>
             <Octicons name="alert" size={16} color="black" />{" "}
@@ -143,15 +145,16 @@ function AppInfo({ account }: { account: Account }) {
 
   return (
     <View style={ss.container.ph16}>
-      <TextH2>App and device</TextH2>
+      <TextH2>Details</TextH2>
       <Spacer h={16} />
-      <KV label="Commit" value={env.gitHash} />
-      <KV label="Profile" value={env.buildProfile} />
-      <KV label="Native Version" value={env.nativeApplicationVersion} />
-      <KV label="Native Build" value={env.nativeBuildVersion} />
+      <KV label="Platform" value={`${Platform.OS} ${Platform.Version}`} />
+      <KV
+        label="Version"
+        value={`${env.nativeApplicationVersion} #${env.nativeBuildVersion}`}
+      />
+      <KV label="Commit" value={`${env.gitHash} ${env.buildProfile}`} />
       {sec && (
         <>
-          <KV label="Platform" value={`${Platform.OS} ${Platform.Version}`} />
           <KV
             label="Biometric Security"
             value={sec.biometricSecurityLevel.toLowerCase()}

--- a/apps/daimo-mobile/src/view/screen/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/OnboardingScreen.tsx
@@ -22,7 +22,6 @@ import {
   useLoadAccountFromKey,
   useLoadKeyFromEnclave,
 } from "../../logic/enclave";
-import { getPushNotificationManager } from "../../logic/notify";
 import { rpcHook } from "../../logic/trpc";
 import { defaultEnclaveKeyName, useAccount } from "../../model/account";
 import { ButtonBig, ButtonSmall } from "../shared/Button";
@@ -172,8 +171,6 @@ function AllowNotifications({ onNext }: { onNext: () => void }) {
     const status = await Notifications.requestPermissionsAsync();
     console.log(`[ONBOARDING] notifications request ${status.status}`);
     if (!status.granted) return;
-
-    getPushNotificationManager().maybeSavePushTokenForAccount();
 
     onNext();
   };

--- a/apps/daimo-mobile/src/view/screen/receive/ClaimNoteScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/ClaimNoteScreen.tsx
@@ -1,4 +1,10 @@
-import { assert, getAccountName, hasAccountName } from "@daimo/common";
+import {
+  OpStatus,
+  assert,
+  getAccountName,
+  hasAccountName,
+} from "@daimo/common";
+import { ephemeralNotesAddress } from "@daimo/contract";
 import { DaimoAccount } from "@daimo/userop";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ReactNode, useEffect, useState } from "react";
@@ -108,7 +114,15 @@ function NoteDisplay({
 
   const { status, message, exec } = useSendAsync(
     account.enclaveKeyName,
-    sendFn(ephemeralNote.owner, ephemeralSignature)
+    sendFn(ephemeralNote.owner, ephemeralSignature),
+    {
+      type: "transfer",
+      status: OpStatus.pending,
+      from: ephemeralNotesAddress,
+      to: account.address,
+      amount: Number(ephemeralNote.amount),
+      timestamp: Date.now() / 1e3,
+    }
   );
 
   // TODO: load estimated fees

--- a/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
@@ -3,13 +3,14 @@ import { Octicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
 import { useCallback, useEffect, useState } from "react";
 import { StyleSheet, Text, TouchableHighlight, View } from "react-native";
-import { Address } from "viem";
+import { Address, getAddress } from "viem";
 
 import { chainConfig } from "../../../logic/chainConfig";
 import { rpcHook } from "../../../logic/trpc";
 import { getAccountManager, useAccount } from "../../../model/account";
 import { ButtonMed } from "../../shared/Button";
 import Spacer from "../../shared/Spacer";
+import { cacheEAccounts } from "../../shared/addr";
 import { color, ss, touchHighlightUnderlay } from "../../shared/style";
 import { TextBody, TextBold, TextLight } from "../../shared/text";
 
@@ -48,6 +49,7 @@ function TestnetFaucet({ recipient }: { recipient: Address }) {
   useEffect(() => {
     if (!mutation.isSuccess) return;
     getAccountManager().addPendingOp(mutation.data);
+    cacheEAccounts([{ addr: getAddress(mutation.data.from), label: "faucet" }]);
   }, [mutation.isSuccess]);
 
   // Display

--- a/apps/daimo-mobile/src/view/screen/send/CreateNoteTab.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/CreateNoteTab.tsx
@@ -1,4 +1,11 @@
-import { DaimoLink, assert, formatDaimoLink } from "@daimo/common";
+import {
+  DaimoLink,
+  OpStatus,
+  assert,
+  dollarsToAmount,
+  formatDaimoLink,
+} from "@daimo/common";
+import { ephemeralNotesAddress } from "@daimo/contract";
 import { DaimoAccount } from "@daimo/userop";
 import {
   ReactNode,
@@ -63,6 +70,14 @@ export function CreateNoteTab({ hide }: { hide: () => void }) {
         `${dollars}`,
         !isNotesContractApproved
       );
+    },
+    {
+      type: "transfer",
+      status: OpStatus.pending,
+      from: account.address,
+      to: ephemeralNotesAddress,
+      amount: Number(dollarsToAmount(dollars)),
+      timestamp: Date.now() / 1e3,
     }
   );
 

--- a/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
@@ -120,8 +120,6 @@ function SetAmount({
   if (account == null) return null;
   const dollarStr = getAmountText({ amount: account.lastBalance });
 
-  console.log(`WTF sendscreen render ${d}`);
-
   return (
     <>
       <Spacer h={64} />

--- a/apps/daimo-mobile/src/view/shared/Input.tsx
+++ b/apps/daimo-mobile/src/view/shared/Input.tsx
@@ -93,15 +93,15 @@ export function AmountInput({
     const newVal = parseLocalFloat(text);
 
     // Handle invalid or entry, NaN etc
-    if (newVal <= 0) {
+    if (!(newVal > 0)) {
       onChange(0);
       return;
     }
 
     // Update number
     onChange(newVal);
-    const fullLength = newVal.toFixed(2).length;
-    if (text.length === fullLength && text.length > strVal.length) {
+    const nEnteredDecimals = (text.split(amountSeparator)[1] || "").length;
+    if (nEnteredDecimals === 2 && text.length > strVal.length) {
       // User just typed in the full amount, down to the cent. Submit.
       if (innerRef?.current) innerRef.current.blur();
       if (onSubmitEditing) onSubmitEditing(newVal);


### PR DESCRIPTION
- Allow Notifications during onboarding > automatically register push token later, once account exists
- make the app feel faster
  - show pending op right after onboarding, on faucet request
  - show pending op for Create Note
  - show pending op for Claim Note