### PR TITLE
Add assetlinks for android

### DIFF
--- a/apps/daimo-web/public/.well-known/assetlinks.json
+++ b/apps/daimo-web/public/.well-known/assetlinks.json
@@ -1,0 +1,13 @@
+[
+    {
+      "relation": ["delegate_permission/common.handle_all_urls"],
+      "target": {
+        "namespace": "android_app",
+        "package_name": "com.daimo",
+        "sha256_cert_fingerprints": [
+          "7C:1D:F7:A7:F4:85:A4:25:4C:FF:4D:B8:EF:0C:07:9F:1B:E3:CB:D3:DE:17:82:6C:A8:F4:3F:7D:58:A7:A8:D2"
+        ]
+      }
+    }
+  ]
+  


### PR DESCRIPTION
assetslinks.json is necessary for android app links to work out of the box