### PR TITLE
Fix depcheck Next config fail

### DIFF
--- a/apps/daimo-web/next.config.js
+++ b/apps/daimo-web/next.config.js
@@ -9,10 +9,12 @@ const nextConfig = {
     ];
   },
   webpack: (config) => {
-    config.externals.push({
-      bufferutil: "bufferutil",
-      "utf-8-validate": "utf-8-validate",
-    });
+    if (config.externals !== undefined) {
+      config.externals.push({
+        bufferutil: "bufferutil",
+        "utf-8-validate": "utf-8-validate",
+      });
+    }
     return config;
   },
 };


### PR DESCRIPTION
Fixes our instance of https://github.com/depcheck/depcheck/issues/812, I don't like that we have to change our code to make our linter tooling work correctly in general.

Before:
<img width="1215" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/70e866df-e315-4ac9-81c0-65230ae4ae8e">


After:
<img width="787" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/78ae9076-b912-4f82-81ce-8b420abf8cfb">
