### PR TITLE
fix: send, cleaner useSendAsync, note > payment link

### DIFF
--- a/apps/daimo-mobile/src/action/actStatus.ts
+++ b/apps/daimo-mobile/src/action/actStatus.ts
@@ -11,6 +11,8 @@ export type SetActStatus = (
 export interface ActHandle {
   /** Action status */
   status: ActStatus;
+  /** Action costs, including fees and total. */
+  cost: { feeDollars: number; totalDollars: number };
   /** Empty when idle. Describes progress, success, or failure. */
   message: string;
   /** Should be called only when status is 'idle' */

--- a/apps/daimo-mobile/src/action/useCreateAccount.ts
+++ b/apps/daimo-mobile/src/action/useCreateAccount.ts
@@ -74,7 +74,7 @@ export function useCreateAccount(name: string): ActHandle {
     setAS("success", "Account created");
   }, [result.isSuccess, result.isError]);
 
-  return { ...as, exec };
+  return { ...as, exec, cost: { feeDollars: 0, totalDollars: 0 } };
 }
 
 function getKeySecurityMessage(hwSecLevel: ExpoEnclave.HardwareSecurityLevel) {

--- a/apps/daimo-mobile/src/action/useSendAsync.ts
+++ b/apps/daimo-mobile/src/action/useSendAsync.ts
@@ -59,17 +59,17 @@ export function useWarmCache(enclaveKeyName?: string, address?: Address) {
 const accountCache: Map<string, Promise<DaimoAccount>> = new Map();
 
 function loadAccount(enclaveKeyName: string, address: Address) {
-  let promise = accountCache.get(enclaveKeyName);
+  let promise = accountCache.get(address);
   if (promise) return promise;
 
   promise = (async () => {
-    console.info(`[SEND] loading DaimoAccount ${enclaveKeyName}`);
+    console.info(`[SEND] loading DaimoAccount ${address} ${enclaveKeyName}`);
     const signer: SigningCallback = (hexTx: string) =>
       requestEnclaveSignature(enclaveKeyName, hexTx);
 
     return await DaimoAccount.init(address, signer, false);
   })();
-  accountCache.set(enclaveKeyName, promise);
+  accountCache.set(address, promise);
 
   return promise;
 }

--- a/apps/daimo-mobile/src/view/screen/send/CreateNoteTab.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/CreateNoteTab.tsx
@@ -165,7 +165,7 @@ export function CreateNoteTab({ hide }: { hide: () => void }) {
 
   return (
     <>
-      <CancelHeader hide={hide}>Creating note</CancelHeader>
+      <CancelHeader hide={hide}>Creating payment link</CancelHeader>
       <Spacer h={32} />
       <AmountInput
         dollars={dollars}

--- a/apps/daimo-mobile/src/view/shared/Amount.tsx
+++ b/apps/daimo-mobile/src/view/shared/Amount.tsx
@@ -8,28 +8,37 @@ import { color, ss } from "./style";
 /** 1.23 or 1,23 depending on user locale */
 export const amountSeparator = getLocales()[0].decimalSeparator || ".";
 
-/** Returns eg "$1.23" or "$1,23" */
+/** Returns eg "$1.00" or "$1,23" or "$1.2345" */
 export function getAmountText({
   dollars,
   amount,
   symbol,
+  fullPrecision,
 }: {
-  dollars?: `${number}`;
+  dollars?: `${number}` | number;
   amount?: bigint;
   symbol?: string;
+  fullPrecision?: boolean;
 }) {
   if (dollars == null) {
     if (amount == null) throw new Error("Missing amount");
+    // Amount specified, calculate dollars string
     dollars = amountToDollars(amount);
+  } else if (amount == null) {
+    // Dollars specified, normalize to string
+    if (typeof dollars === "number") {
+      dollars = dollars.toFixed(2) as `${number}`;
+    }
   } else {
-    if (amount != null) throw new Error("Specify amount or dollars, not both");
+    throw new Error("Specify amount or dollars, not both");
   }
 
   if (symbol == null) {
     symbol = "$";
   }
   const [wholeDollars, cents] = dollars.split(".");
-  return `${symbol}${wholeDollars}${amountSeparator}${cents}`;
+  const dispCents = fullPrecision ? cents : cents.slice(0, 2);
+  return `${symbol}${wholeDollars}${amountSeparator}${dispCents}`;
 }
 
 /** Displays eg "$1.23" or "$1,23" as H1 or H2. */

--- a/apps/daimo-mobile/src/view/shared/Input.tsx
+++ b/apps/daimo-mobile/src/view/shared/Input.tsx
@@ -61,14 +61,15 @@ export function AmountInput({
 }) {
   if (dollars < 0) throw new Error("AmountPicker value can't be negative");
 
-  const fmt = (dollars: number) =>
-    getAmountText({ dollars: dollars.toFixed(2) as `${number}`, symbol: "" });
+  const fmt = (dollars: number) => getAmountText({ dollars, symbol: "" });
 
   const [strVal, setStrVal] = useState(dollars <= 0 ? "" : fmt(dollars));
 
   // On end editing, round value to 2 decimal places
   const onEndEditing = (e: { nativeEvent: { text: string } }) => {
     const value = e.nativeEvent.text;
+    console.log(`[INPUT] onEndEditing ${value}`);
+
     let newVal = parseLocalFloat(value);
     if (!(newVal >= 0)) {
       newVal = 0;
@@ -102,6 +103,7 @@ export function AmountInput({
   }, []);
 
   const onSubmit = useCallback(() => {
+    console.log(`[INPUT] onSubmitEditing ${dollars}`);
     if (onSubmitEditing) onSubmitEditing(dollars);
   }, [dollars]);
 
@@ -112,7 +114,6 @@ export function AmountInput({
       keyboardType="numeric"
       placeholder={`0${amountSeparator}00`}
       placeholderTextColor={color.gray}
-      multiline
       numberOfLines={1}
       autoFocus={autoFocus == null ? true : autoFocus}
       value={strVal}

--- a/packages/daimo-api/src/contract/nameRegistry.ts
+++ b/packages/daimo-api/src/contract/nameRegistry.ts
@@ -21,9 +21,9 @@ type RegisteredLog = Log<bigint, number, false, typeof registeredEvent, true>;
 
 const specialAddrLabels: { [_: Address]: string } = {
   "0x2A6d311394184EeB6Df8FBBF58626B085374Ffe7": "faucet",
-  "0x37Ac8550dA1E8d227266966A0b4925dfae648f7f": "note", // Old Notes contract
+  "0x37Ac8550dA1E8d227266966A0b4925dfae648f7f": "payment link",
 };
-specialAddrLabels[ephemeralNotesAddress] = "note";
+specialAddrLabels[ephemeralNotesAddress] = "payment link";
 
 /* Interface to the NameRegistry contract. */
 export class NameRegistry {


### PR DESCRIPTION
fixes #77 

 - [x] note > link
 - [x] explain what a Payment Link is. subtitle “This will create a link that can be redeemed by anyone with a Daimo account or an Ethereum wallet”