### PR TITLE
expo-enclave: Don't throw on failed reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22495,10 +22495,6 @@
       "name": "@daimo/expo-enclave",
       "version": "0.1.0",
       "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@daimo/contract": "*",
-        "@daimo/userop": "*"
-      },
       "devDependencies": {
         "@types/react": "^18.2.15",
         "@types/react-native": "^0.72.2",

--- a/packages/daimo-expo-enclave/package.json
+++ b/packages/daimo-expo-enclave/package.json
@@ -24,10 +24,7 @@
   "homepage": "https://github.com/daimo-eth/daimo#readme",
   "repository": "https://github.com/daimo-eth/daimo/tree/master/packages/daimo-expo-enclave",
   "author": "Daimo",
-  "dependencies": {
-    "@daimo/contract": "*",
-    "@daimo/userop": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-native": "^0.72.2",

--- a/packages/daimo-expo-enclave/src/index.ts
+++ b/packages/daimo-expo-enclave/src/index.ts
@@ -51,17 +51,7 @@ export async function getBiometricSecurityLevel(): Promise<BiometricSecurityLeve
 export async function fetchPublicKey(
   accountName: string
 ): Promise<string | undefined> {
-  try {
-    return ExpoEnclaveModule.fetchPublicKey(accountName);
-  } catch (e) {
-    const message: string = e.message || "";
-    if (message.startsWith("Unable to read account")) {
-      // TODO: consider updating native code to return null instead of throwing.
-      return undefined;
-    } else {
-      throw e;
-    }
-  }
+  return ExpoEnclaveModule.fetchPublicKey(accountName);
 }
 
 /**


### PR DESCRIPTION
Unclear why #191 happens since we're explicitly catching those throws (possible @dcposch had an old module build somehow?), this PR should clean up that throw logic anyway.