### PR TITLE
Add user presence access control to fallback key manager keychain auth

### DIFF
--- a/apps/daimo-mobile/src/model/account.ts
+++ b/apps/daimo-mobile/src/model/account.ts
@@ -18,7 +18,7 @@ import { cacheEAccounts } from "../view/shared/addr";
  * Singleton account key.
  * Will be a series if/when we support multiple accounts.
  */
-export const defaultEnclaveKeyName = "daimo-10";
+export const defaultEnclaveKeyName = "daimo-11";
 
 /** Account data stored on device. */
 export type Account = {

--- a/packages/daimo-expo-enclave/ios/FallbackKeyManager.swift
+++ b/packages/daimo-expo-enclave/ios/FallbackKeyManager.swift
@@ -21,7 +21,7 @@ public class FallbackKeyManager : KeyManager {
     internal func createSigningPrivkey(accountName: String) throws {
         let signingPrivkey = P256.Signing.PrivateKey()
         
-        try self.store.storeKey(signingPrivkey, account: accountName)
+        try self.store.storeKey(signingPrivkey, account: accountName, requireUserPresence: true)
     }
 
     internal func getSigningPrivkey(accountName: String) throws -> P256.Signing.PrivateKey {

--- a/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
+++ b/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
@@ -50,6 +50,10 @@ public class SecureEnclaveKeyManager : KeyManager {
         
         let signingPrivkey = try SecureEnclave.P256.Signing.PrivateKey(accessControl: accessControl)
         
+        // Since the key is authed by the enclave and the keychain only stores an encrypted blob
+        // representation, we do not auth userPresence for keychain reads. Additionally, it would
+        // be bad UX to prompt the user for presence/auth twice (seperately for keychain reads and
+        // on Secure Enclave signing).
         try self.store.storeKey(signingPrivkey, account: accountName, requireUserPresence: false)
     }
 

--- a/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
+++ b/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
@@ -50,7 +50,7 @@ public class SecureEnclaveKeyManager : KeyManager {
         
         let signingPrivkey = try SecureEnclave.P256.Signing.PrivateKey(accessControl: accessControl)
         
-        try self.store.storeKey(signingPrivkey, account: accountName)
+        try self.store.storeKey(signingPrivkey, account: accountName, requireUserPresence: false)
     }
 
     public func fetchPublicKey(accountName: String) throws -> String? {


### PR DESCRIPTION
Veridise Audit ID 9

Tested on few different iOS configurations:
- Face ID enabled, secure enclave
- iOS Simulator, software keys
- Face ID enabled, Secure Enclave forcefully disabled so using Fallback settings (by hardcoding `shouldUseSecureEnclave` in swift expo-enclave module)