### PR TITLE
fix: header spacing, colors

### DIFF
--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -1,6 +1,7 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { StatusBar } from "expo-status-bar";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { useInitNotifications } from "./logic/notify";
 import { RpcProvider } from "./logic/trpc";
@@ -34,9 +35,9 @@ function AppBody() {
   useInitNavLinks();
 
   return (
-    <>
+    <SafeAreaProvider>
       <HomeStackNav />
       <StatusBar style="auto" />
-    </>
+    </SafeAreaProvider>
   );
 }

--- a/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import Octicons from "@expo/vector-icons/Octicons";
 import { useCallback } from "react";
 import { Dimensions, StyleSheet, TouchableHighlight, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { HistoryList, HistoryScreen } from "./HistoryScreen";
 import { useWarmCache } from "../../action/useSendAsync";
@@ -35,7 +36,7 @@ export default function HomeScreen() {
   if (account == null) return null;
 
   return (
-    <View style={ss.container.fullWidthScroll}>
+    <SafeAreaView style={ss.container.fullWidthScroll}>
       <Header />
 
       <View style={styles.amountAndButtonsContainer}>
@@ -53,9 +54,9 @@ export default function HomeScreen() {
         onShowFull={() => setIsHistoryOpened(true)}
         animation="spring"
         extraMarginTop={0}
-        swipeHeight={256}
+        swipeHeight={192}
       />
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -151,7 +152,7 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
-    height: 400,
+    height: screenDimensions.height - 256,
   },
   buttonRow: {
     flexDirection: "row",

--- a/apps/daimo-mobile/src/view/screen/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/OnboardingScreen.tsx
@@ -249,7 +249,7 @@ function PageBubble({ count, index }: { count: number; index: number }) {
           width: 8,
           height: 8,
           borderRadius: 4,
-          backgroundColor: i === index ? "#000" : "#ccc",
+          backgroundColor: i === index ? color.midnight : color.grayLight,
           margin: 4,
         }}
       />
@@ -478,7 +478,7 @@ function UseExistingPage({
           <View style={styles.vertQR}>
             <QRCode
               value={createAddDeviceString(pubKeyHex)}
-              color="#333"
+              color={color.grayDark}
               size={256}
               logo={{ uri: image.qrLogo }}
               logoSize={72}
@@ -521,7 +521,7 @@ function OnboardingHeader({ onPrev }: { onPrev?: () => void }) {
                 <Octicons
                   name="chevron-left"
                   size={20}
-                  color={color.grayDark}
+                  color={color.midnight}
                 />
                 <Text style={styles.onboardingBackText}>Back</Text>
               </>
@@ -648,7 +648,7 @@ const screenDimensions = Dimensions.get("screen");
 const styles = StyleSheet.create({
   onboardingScreen: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: color.white,
     alignItems: "center",
     justifyContent: "space-around",
   },
@@ -668,7 +668,7 @@ const styles = StyleSheet.create({
   },
   onboardingBackText: {
     ...ss.text.h3,
-    color: color.grayDark,
+    color: color.midnight,
   },
   introPages: {
     alignItems: "center",

--- a/apps/daimo-mobile/src/view/screen/SettingsScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/SettingsScreen.tsx
@@ -273,11 +273,6 @@ const styles = StyleSheet.create({
     padding: 16,
     alignItems: "stretch",
   },
-  callout: {
-    backgroundColor: color.grayLight,
-    padding: 16,
-    borderRadius: 24,
-  },
   keyValueList: {
     ...ss.container.padH16,
     flex: 1,

--- a/apps/daimo-mobile/src/view/screen/receive/CreateRequestScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/CreateRequestScreen.tsx
@@ -5,12 +5,11 @@ import QRCode from "react-native-qrcode-svg";
 
 import { useAccount } from "../../../model/account";
 import { ButtonBig } from "../../shared/Button";
-import { Header } from "../../shared/Header";
 import Spacer from "../../shared/Spacer";
 import image from "../../shared/image";
 import { useNav } from "../../shared/nav";
-import { ss } from "../../shared/style";
-import { TextLight } from "../../shared/text";
+import { color, ss } from "../../shared/style";
+import { TextBody, TextLight } from "../../shared/text";
 
 export default function CreateRequestScreen() {
   const nav = useNav();
@@ -23,22 +22,21 @@ export default function CreateRequestScreen() {
 
   return (
     <View style={ss.container.fullWidthSinglePage}>
-      <Header />
       <Spacer h={64} />
       <View style={styles.vertMain}>
         <View style={styles.vertQR}>
           <QRCode
             value={url}
-            color="#333"
+            color={color.grayDark}
             size={192}
             logo={{ uri: image.qrLogo }}
             logoSize={72}
           />
-          <TextLight>Scan or tap</TextLight>
+          <TextBody>Scan to pay</TextBody>
         </View>
-        <Spacer h={32} />
+        <Spacer h={48} />
         <TextLight>or</TextLight>
-        <Spacer h={32} />
+        <Spacer h={48} />
         <View style={styles.horzButtons}>
           <ButtonBig type="primary" title="Send Request" onPress={send} />
         </View>

--- a/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
@@ -156,7 +156,7 @@ const styles = StyleSheet.create({
   },
   addressButton: {
     borderRadius: 8,
-    backgroundColor: color.grayLight,
+    backgroundColor: color.ivoryDark,
     padding: 16,
   },
   addressView: {
@@ -169,7 +169,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   callout: {
-    backgroundColor: color.grayLight,
+    backgroundColor: color.ivoryDark,
     padding: 16,
     marginHorizontal: -16,
     borderRadius: 24,

--- a/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
@@ -21,7 +21,7 @@ import { ButtonWithStatus } from "../../shared/ButtonWithStatus";
 import Spacer from "../../shared/Spacer";
 import { ErrorRowCentered } from "../../shared/error";
 import { HomeStackParamList, useNav } from "../../shared/nav";
-import { ss } from "../../shared/style";
+import { color, ss } from "../../shared/style";
 import { TextBody, TextCenter, TextH2 } from "../../shared/text";
 
 type Props = NativeStackScreenProps<HomeStackParamList, "Send">;
@@ -64,7 +64,7 @@ function SendNav() {
         onValueChange={setTab}
         fontStyle={{ fontSize: 16 }}
         activeFontStyle={{ fontSize: 16 }}
-        style={{ height: 40 }}
+        style={{ height: 40, backgroundColor: color.ivoryDark }}
       />
       <Spacer h={8} />
       {tab === "Search" && <SearchTab />}

--- a/apps/daimo-mobile/src/view/shared/Amount.tsx
+++ b/apps/daimo-mobile/src/view/shared/Amount.tsx
@@ -84,6 +84,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
   },
   titleGray: {
-    color: color.gray,
+    color: color.grayMid,
   },
 });

--- a/apps/daimo-mobile/src/view/shared/AmountInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AmountInput.tsx
@@ -124,7 +124,7 @@ function AmountInput({
           style={styles.amountInput}
           keyboardType="numeric"
           placeholder="0"
-          placeholderTextColor={color.gray}
+          placeholderTextColor={color.grayMid}
           numberOfLines={1}
           focusable={!disabled}
           editable={!disabled}
@@ -156,7 +156,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     fontSize: 36,
     fontWeight: "bold",
-    color: color.black,
+    color: color.midnight,
   },
 });
 

--- a/apps/daimo-mobile/src/view/shared/Button.tsx
+++ b/apps/daimo-mobile/src/view/shared/Button.tsx
@@ -133,7 +133,7 @@ export const buttonStyles = {
       paddingHorizontal: 24,
       paddingVertical: 16,
       borderRadius: 8,
-      backgroundColor: color.primaryLight,
+      backgroundColor: color.primaryBgLight,
     },
     title: {
       fontSize: 20,
@@ -146,7 +146,7 @@ export const buttonStyles = {
       paddingHorizontal: 16,
       paddingVertical: 12,
       borderRadius: 8,
-      backgroundColor: color.primaryLight,
+      backgroundColor: color.primaryBgLight,
     },
     title: {
       fontSize: 16,
@@ -164,7 +164,7 @@ export const buttonStyles = {
       fontSize: 16,
       fontWeight: "600",
       textAlign: "center",
-      color: color.grayDark,
+      color: color.midnight,
     },
   }),
 };

--- a/apps/daimo-mobile/src/view/shared/Header.tsx
+++ b/apps/daimo-mobile/src/view/shared/Header.tsx
@@ -41,13 +41,13 @@ const styles = StyleSheet.create({
   },
   pellet: {
     borderRadius: 4,
-    backgroundColor: color.grayLight,
+    backgroundColor: color.ivoryDark,
     paddingHorizontal: 8,
     paddingVertical: 4,
   },
   pelletText: {
     ...ss.text.body,
     fontWeight: "bold",
-    color: color.gray,
+    color: color.grayMid,
   },
 });

--- a/apps/daimo-mobile/src/view/shared/InfoLink.tsx
+++ b/apps/daimo-mobile/src/view/shared/InfoLink.tsx
@@ -10,7 +10,7 @@ export function InfoLink({ url, title }: { url: string; title: string }) {
     <View style={ss.container.marginHNeg16}>
       <ButtonSmall onPress={() => Linking.openURL(url)}>
         <TextLight>
-          <Octicons name="info" size={16} color={color.gray} />
+          <Octicons name="info" size={16} color={color.grayMid} />
           {` \u00A0 `}
           {title}
         </TextLight>

--- a/apps/daimo-mobile/src/view/shared/InputBig.tsx
+++ b/apps/daimo-mobile/src/view/shared/InputBig.tsx
@@ -31,7 +31,7 @@ export function InputBig({
     <View style={isFocused ? styles.inputRowFocused : styles.inputRow}>
       <TextInput
         placeholder={placeholder}
-        placeholderTextColor={color.gray}
+        placeholderTextColor={color.grayMid}
         value={value}
         onChangeText={onChange}
         style={center ? styles.inputCentered : styles.input}
@@ -52,7 +52,7 @@ const inputRow = {
   flexDirection: "row",
   alignItems: "center",
   gap: 8,
-  backgroundColor: color.grayLight,
+  backgroundColor: color.ivoryDark,
   borderRadius: 8,
   paddingHorizontal: 16,
   paddingVertical: 12,

--- a/apps/daimo-mobile/src/view/shared/ScrollPellet.tsx
+++ b/apps/daimo-mobile/src/view/shared/ScrollPellet.tsx
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   scrollPellet: {
-    backgroundColor: color.gray,
+    backgroundColor: color.grayMid,
     width: 96,
     height: 4,
     borderRadius: 2,

--- a/apps/daimo-mobile/src/view/shared/style.ts
+++ b/apps/daimo-mobile/src/view/shared/style.ts
@@ -1,21 +1,23 @@
 import { Platform, StyleSheet, TextStyle } from "react-native";
 
+/** Match daimo-web tailwind config. Same name = refers to the same color. */
 export const color = {
   primary: "#007aff",
-  primaryLight: "#aaccff",
+  primaryBgLight: "#aaccff",
   danger: "#f35369",
   success: "#4cd964",
-  successDark: "#090",
-  black: "#000",
-  grayDark: "#222",
-  gray: "#668",
-  grayLight: "#eef0f4",
-  white: "#fff",
+  successDark: "#009900",
+  white: "#ffffff",
+  ivoryDark: "#f2f2f2",
+  grayLight: "#e2e2e2",
+  grayMid: "#717171",
+  grayDark: "#444",
+  midnight: "#262626",
 };
 
 const textBase: TextStyle = {
   fontVariant: ["tabular-nums"],
-  color: color.black,
+  color: color.midnight,
 };
 
 const activeAlpha = "aa";
@@ -31,7 +33,7 @@ export const touchHighlightUnderlay = {
     underlayColor: color.success + activeAlpha,
   },
   subtle: {
-    underlayColor: color.primaryLight + activeAlpha,
+    underlayColor: color.primaryBgLight + activeAlpha,
   },
 };
 
@@ -51,8 +53,6 @@ export const ss = {
     },
     fullWidthScroll: {
       ...styleFullWidth,
-      paddingBottom: 0,
-      paddingTop: 48,
     },
     fullWidthModal: {
       ...styleFullWidth,
@@ -100,11 +100,11 @@ export const ss = {
       fontSize: 16,
       lineHeight: 24,
     },
-    small: {
+    light: {
       ...textBase,
       fontSize: 16,
       lineHeight: 20,
-      color: color.gray,
+      color: color.grayMid,
     },
     error: {
       ...textBase,

--- a/apps/daimo-mobile/src/view/shared/text.tsx
+++ b/apps/daimo-mobile/src/view/shared/text.tsx
@@ -21,7 +21,7 @@ export function TextBody(props: TextProps) {
 }
 
 export function TextLight(props: TextProps) {
-  return <Text {...props} style={ss.text.small} />;
+  return <Text {...props} style={ss.text.light} />;
 }
 
 export function TextBold(props: TextProps) {


### PR DESCRIPTION
match @daimo/web colors

use `<SafeAreaView/>` to pad the header properly

<img width="220" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/fd62b7a2-e873-45f4-a3b5-a248f0923dc7">
