### PR TITLE
fix: handle request link

### DIFF
--- a/apps/daimo-mobile/src/view/screen/send/CancelHeader.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/CancelHeader.tsx
@@ -14,14 +14,18 @@ export function CancelHeader({
   hide?: () => void;
 }) {
   return (
-    <ButtonSmall onPress={hide}>
-      <View style={styles.cancelHeader}>
-        <Spacer w={12} />
-        <TextLight>{children}</TextLight>
-        {hide && <Octicons name="x" size={20} color="gray" />}
-        {!hide && <Spacer w={12} />}
-      </View>
-    </ButtonSmall>
+    <View style={styles.cancelHeader}>
+      <Spacer w={64} />
+      <TextLight>{children}</TextLight>
+      {hide && (
+        <ButtonSmall onPress={hide}>
+          <View style={styles.cancelButton}>
+            <Octicons name="x" size={24} color="gray" />
+          </View>
+        </ButtonSmall>
+      )}
+      {!hide && <Spacer w={64} />}
+    </View>
   );
 }
 
@@ -30,6 +34,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingLeft: 8,
+  },
+  cancelButton: {
+    width: 32,
+    height: 40,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
   },
 });

--- a/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
@@ -87,9 +87,10 @@ function SendLoadRecipient({ link }: { link: DaimoLink }) {
         break;
       }
       case "request": {
-        // TODO: handle fulfilledBy
+        // TODO: handle fulfilledBy (request already completed)
         const { recipient, requestId } = data as DaimoRequestStatus;
-        nav.setParams({ recipient, requestId });
+        const { dollars } = data.link;
+        nav.setParams({ recipient, requestId, dollars });
         break;
       }
     }

--- a/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendScreen.tsx
@@ -34,14 +34,13 @@ const SegmentedControlFixed = SegmentedControl as any;
 export default function SendScreen({ route }: Props) {
   console.log(`[SEND] rendering SendScreen ${JSON.stringify(route.params)}}`);
   const { link, recipient, dollars, requestId } = route.params || {};
-
   return (
     <View style={ss.container.fullWidthSinglePage}>
       <KeyboardAvoidingView behavior="height" keyboardVerticalOffset={128}>
         {!recipient && !link && <SendNav /> /* User picks who to pay */}
         {!recipient && link && <SendLoadRecipient {...{ link }} />}
         {recipient && dollars == null && (
-          <SendChooseAmount {...{ recipient }} />
+          <SendChooseAmount recipient={recipient} />
         )}
         {recipient && dollars != null && (
           <SendConfirm {...{ recipient, dollars, requestId }} />
@@ -149,11 +148,12 @@ function SendConfirm({
   requestId?: `${bigint}`;
 }) {
   const nDollars = parseFloat(dollars);
+  const isRequest = requestId != null;
   return (
     <View>
       <Spacer h={32} />
       <AmountChooser
-        actionDesc={<DescSendToRecipient recipient={recipient} />}
+        actionDesc={<DescSendToRecipient {...{ recipient, isRequest }} />}
         dollars={nDollars}
         onSetDollars={useCallback(() => {}, [])}
         disabled
@@ -165,14 +165,20 @@ function SendConfirm({
   );
 }
 
-function DescSendToRecipient({ recipient }: { recipient: Recipient }) {
+function DescSendToRecipient({
+  recipient,
+  isRequest,
+}: {
+  recipient: Recipient;
+  isRequest?: boolean;
+}) {
   // Show who we're sending to
   const disp = getAccountName(recipient);
 
   return (
     <View>
       <TextCenter>
-        <TextBody>Sending to</TextBody>
+        <TextBody>{isRequest ? "Requested by" : "Sending to"}</TextBody>
       </TextCenter>
       <TextCenter>
         <TextH2>{disp}</TextH2>

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -56,8 +56,12 @@ export function useInitNavLinks() {
 
   useEffect(() => {
     if (accountMissing) return;
-    console.log(`[NAV] listening for deep links ${account}`);
-    getInitialURL().then((url) => url && handleDeepLink(nav, url));
+    console.log(`[NAV] listening for deep links, account ${account.name}`);
+    getInitialURL().then((url) => {
+      // Workdaround: avoid "The 'navigation' object hasn't been initialized"
+      if (url == null) return;
+      setTimeout(() => handleDeepLink(nav, url), 100);
+    });
     addEventListener("url", ({ url }) => handleDeepLink(nav, url));
   }, [accountMissing]);
 }

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -46,24 +46,23 @@ export function useNav<
   >();
 }
 
-type HomeStackNavProp = ReturnType<typeof useNav>;
+export type HomeStackNav = ReturnType<typeof useNav>;
 
 /** Handle incoming app deep links. */
 export function useInitNavLinks() {
   const nav = useNav();
   const [account] = useAccount();
-  const accountNotNull = account != null;
+  const accountMissing = account == null;
 
   useEffect(() => {
-    if (accountNotNull) {
-      console.log(`[NAV] listening for deep links ${account}`);
-      getInitialURL().then((url) => url && handleDeepLink(nav, url));
-      addEventListener("url", ({ url }) => handleDeepLink(nav, url));
-    }
-  }, [accountNotNull]);
+    if (accountMissing) return;
+    console.log(`[NAV] listening for deep links ${account}`);
+    getInitialURL().then((url) => url && handleDeepLink(nav, url));
+    addEventListener("url", ({ url }) => handleDeepLink(nav, url));
+  }, [accountMissing]);
 }
 
-function handleDeepLink(nav: HomeStackNavProp, url: string) {
+export function handleDeepLink(nav: HomeStackNav, url: string) {
   const link = parseDaimoLink(url);
   if (link == null) {
     console.log(`[NAV] skipping unparseable link ${url}`);
@@ -74,7 +73,7 @@ function handleDeepLink(nav: HomeStackNavProp, url: string) {
   goTo(nav, link);
 }
 
-async function goTo(nav: ReturnType<typeof useNav>, link: DaimoLink) {
+async function goTo(nav: HomeStackNav, link: DaimoLink) {
   const { type } = link;
   switch (type) {
     case "account":

--- a/apps/daimo-mobile/test/nav.test.ts
+++ b/apps/daimo-mobile/test/nav.test.ts
@@ -1,0 +1,50 @@
+import { DaimoLink } from "@daimo/common";
+
+import { HomeStackNav, handleDeepLink } from "../src/view/shared/nav";
+
+describe("nav", () => {
+  const history = [] as { screen: string; params: any }[];
+  const nav: HomeStackNav = {
+    navigate: (screen: string, params: any) => {
+      history.push({ screen, params });
+    },
+  } as any;
+
+  const assertNav = (screen: string, params: { link: DaimoLink }) => {
+    expect(history).toStrictEqual([{ screen, params }]);
+  };
+
+  it("handles account links", () => {
+    history.length = 0;
+    handleDeepLink(nav, "daimo://account/alice");
+    assertNav("Send", { link: { type: "account", account: "alice" } });
+  });
+  it("handles request links", () => {
+    history.length = 0;
+    handleDeepLink(nav, "daimo://request/alice/1.23/456");
+    assertNav("Send", {
+      link: {
+        type: "request",
+        recipient: "alice",
+        dollars: "1.23",
+        requestId: "456",
+      },
+    });
+  });
+  it("handles payment links", () => {
+    history.length = 0;
+    handleDeepLink(
+      nav,
+      "daimo://note/alice/1.23/0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+    );
+    assertNav("Note", {
+      link: {
+        type: "note",
+        previewSender: "alice",
+        previewDollars: "1.23",
+        ephemeralOwner: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ephemeralPrivateKey: undefined,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

we currently show just the recipient, not a prefilled dollar amount

- [x] Hande dollar amount in request link
- [x] Display that we're handling a request
- [x] Add unit test for `nav.ts`

We can discuss integration test strategy for a future PR. I'd love to get something like to the release test checklist automated (though we'd still run through it manually, ofc, for production releases).