### PR TITLE
web: Fix super.so domain

### DIFF
--- a/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
+++ b/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
@@ -11,7 +11,7 @@ export async function GET(request: Request) {
     method: request.method,
     headers: {
       ...request.headers,
-      Host: "daimo.xyz",
+      Host: "daimo.super.site",
     },
   });
 


### PR DESCRIPTION
super.so killed our notion bridge because we pointed daimo.xyz to a different DNS sigh

would recommend pushing to prod asap, this is killing our blog and privacy page etc. ATM