### PR TITLE
@daimo/web: fix Notion proxy

### DIFF
--- a/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
+++ b/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
@@ -1,4 +1,4 @@
-const superSo = "https://cname.super.so";
+const superSo = "https://daimo.super.site";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);


### PR DESCRIPTION
Before, we were proxying to `cname.super.so` which may have rate limited or otherwise blocked us.

Fixed by changing to `daimo.super.site`. Different IP:

```
dc-mbp-m2:daimo-mobile dc$ nslookup cname.super.so
Server:         192.168.1.1
Address:        192.168.1.1#53

Non-authoritative answer:
cname.super.so  canonical name = cname.vercel-dns.com.
Name:   cname.vercel-dns.com
Address: 76.76.21.22
Name:   cname.vercel-dns.com
Address: 76.76.21.9

dc-mbp-m2:daimo-mobile dc$ nslookup daimo.super.site
Server:         192.168.1.1
Address:        192.168.1.1#53

Non-authoritative answer:
Name:   daimo.super.site
Address: 76.76.21.123
Name:   daimo.super.site
Address: 76.76.21.164
```