### PR TITLE
sendUserOp via API

### DIFF
--- a/apps/daimo-mobile/eas.json
+++ b/apps/daimo-mobile/eas.json
@@ -36,7 +36,6 @@
       "node": "20.3.0",
       "env": {
         "DAIMO_APP_API_URL": "https://daimo-api-prod.onrender.com",
-        "DAIMO_BUNDLER_RPC": "https://api.pimlico.io/v1/base/rpc?apikey=70ecef54-a28e-4e96-b2d3-3ad67fbc1b07",
         "DAIMO_CHAIN": "base",
         "DAIMO_DOMAIN": "daimo.xyz"
       }

--- a/apps/scratchpad/src/index.ts
+++ b/apps/scratchpad/src/index.ts
@@ -2,9 +2,10 @@ import { CoinIndexer } from "@daimo/api/src/contract/coinIndexer";
 import { NameRegistry } from "@daimo/api/src/contract/nameRegistry";
 import { OpIndexer } from "@daimo/api/src/contract/opIndexer";
 import { getViemClientFromEnv } from "@daimo/api/src/viemClient";
-import { guessTimestampFromNum } from "@daimo/common";
+import { guessTimestampFromNum, zHex, zUserOpHex } from "@daimo/common";
 import { nameRegistryProxyConfig, chainConfig } from "@daimo/contract";
 import csv from "csvtojson";
+import z from "zod";
 
 import { checkAccount, checkAccountDesc } from "./checkAccount";
 import { createAccount, createAccountDesc } from "./createAccount";

--- a/packages/daimo-api/src/chain/bundlerClient.ts
+++ b/packages/daimo-api/src/chain/bundlerClient.ts
@@ -1,0 +1,28 @@
+import { UserOpHex, assert } from "@daimo/common";
+import { BundlerJsonRpcProvider, Constants } from "userop";
+import { isHex } from "viem";
+
+/** Sends userops through an ERC-4337 bundler. */
+export class BundlerClient {
+  provider: BundlerJsonRpcProvider;
+
+  constructor(bundlerRpcUrl: string) {
+    this.provider = new BundlerJsonRpcProvider(bundlerRpcUrl);
+  }
+
+  async sendUserOp(op: UserOpHex) {
+    console.log(`[BUNDLER] submitting userOp: ${JSON.stringify(op)}`);
+    const args = [op, Constants.ERC4337.EntryPoint];
+    const opHash = await this.provider.send("eth_sendUserOperation", args);
+    assert(isHex(opHash));
+    console.log(`[BUNDLER] submitted userOpHash: ${opHash}`);
+    return opHash;
+  }
+}
+
+/** Requires DAIMO_BUNDLER_RPC_URL. */
+export function getBundlerClientFromEnv() {
+  const rpcUrl = process.env.DAIMO_BUNDLER_RPC || "";
+  assert(rpcUrl !== "", "DAIMO_BUNDLER_RPC env var missing");
+  return new BundlerClient(rpcUrl);
+}

--- a/packages/daimo-api/src/server.ts
+++ b/packages/daimo-api/src/server.ts
@@ -2,6 +2,7 @@ import { chainConfig } from "@daimo/contract";
 import { createHTTPHandler } from "@trpc/server/adapters/standalone";
 import http from "http";
 
+import { getBundlerClientFromEnv } from "./chain/bundlerClient";
 import { AccountFactory } from "./contract/accountFactory";
 import { CoinIndexer } from "./contract/coinIndexer";
 import { Faucet } from "./contract/faucet";
@@ -21,6 +22,7 @@ async function main() {
   console.log(`[API] starting...`);
   const vc = getViemClientFromEnv();
   await vc.init();
+  const bundlerClient = getBundlerClientFromEnv();
 
   console.log(`[API] using wallet ${vc.walletClient.account.address}`);
   const keyReg = new KeyRegistry(vc);
@@ -69,6 +71,7 @@ async function main() {
   console.log(`[API] serving...`);
   const router = createRouter(
     vc,
+    bundlerClient,
     coinIndexer,
     noteIndexer,
     opIndexer,

--- a/packages/daimo-api/src/trpc.ts
+++ b/packages/daimo-api/src/trpc.ts
@@ -1,3 +1,4 @@
+import { Span } from "@opentelemetry/api";
 import { initTRPC } from "@trpc/server";
 import { CreateHTTPContextOptions } from "@trpc/server/adapters/standalone";
 
@@ -9,7 +10,8 @@ export const createContext = async (opts: CreateHTTPContextOptions) => {
   const userAgent = opts.req.headers["user-agent"] || "";
   const daimoPlatform = opts.req.headers["x-daimo-platform"] || "";
   const daimoVersion = opts.req.headers["x-daimo-version"] || "";
-  return { ipAddr, userAgent, daimoPlatform, daimoVersion };
+  const span = null as Span | null;
+  return { ipAddr, userAgent, daimoPlatform, daimoVersion, span };
 };
 
 function getXForwardedIP(opts: CreateHTTPContextOptions) {

--- a/packages/daimo-common/src/model.ts
+++ b/packages/daimo-common/src/model.ts
@@ -20,7 +20,7 @@ export interface DAccount {
 
 export const zHex = z
   .string()
-  .regex(/^0x([0-9a-f]{2})*$/i)
+  .regex(/^0x[0-9a-f]*$/i)
   .refine((s): s is Hex => true);
 
 export const zBigIntStr = z
@@ -54,3 +54,19 @@ export const zKeyData = z.object({
 });
 
 export type KeyData = z.infer<typeof zKeyData>;
+
+export const zUserOpHex = z.object({
+  sender: zAddress,
+  nonce: zHex,
+  initCode: zHex,
+  callData: zHex,
+  callGasLimit: zHex,
+  verificationGasLimit: zHex,
+  preVerificationGas: zHex,
+  maxFeePerGas: zHex,
+  maxPriorityFeePerGas: zHex,
+  paymasterAndData: zHex,
+  signature: zHex,
+});
+
+export type UserOpHex = z.infer<typeof zUserOpHex>;

--- a/packages/daimo-userop/src/callback.ts
+++ b/packages/daimo-userop/src/callback.ts
@@ -1,0 +1,19 @@
+import { UserOpHex } from "@daimo/common";
+import { Hex } from "viem";
+
+// Message signature, along with key slot identifying the signing keypair.
+export interface SigResponse {
+  // Signing key slot, see DaimoAccount.sol
+  keySlot: number;
+  // Hex DER signature
+  derSig: string;
+}
+
+/** Produces a P256 signature for a message. */
+export type SigningCallback = (msgHex: string) => Promise<SigResponse>;
+
+/**
+ * Submits a signed userop, returning the userOpHash once the bundler accepts.
+ * Throws an error otherwise. Does NOT wait for the op to be confirmed onchain.
+ */
+export type OpSenderCallback = (op: UserOpHex) => Promise<Hex>;

--- a/packages/daimo-userop/src/daimoOpBuilder.ts
+++ b/packages/daimo-userop/src/daimoOpBuilder.ts
@@ -19,8 +19,8 @@ import {
   numberToBytes,
 } from "viem";
 
+import { SigningCallback } from "./callback";
 import { DaimoNonce } from "./nonce";
-import { SigningCallback } from "./signingCallback";
 
 // Metadata for a userop: nonce and paymaster constant.
 export type DaimoOpMetadata = {

--- a/packages/daimo-userop/src/index.ts
+++ b/packages/daimo-userop/src/index.ts
@@ -5,4 +5,4 @@ export {
   DaimoNonceType,
   MAX_NONCE_ID_SIZE_BITS,
 } from "./nonce";
-export { SigningCallback } from "./signingCallback";
+export { SigningCallback, OpSenderCallback } from "./callback";

--- a/packages/daimo-userop/src/signingCallback.ts
+++ b/packages/daimo-userop/src/signingCallback.ts
@@ -1,9 +1,0 @@
-// Message signature, along with key slot identifying the signing keypair.
-export interface SigResponse {
-  // Signing key slot, see DaimoAccount.sol
-  keySlot: number;
-  // Hex DER signature
-  derSig: string;
-}
-
-export type SigningCallback = (msgHex: string) => Promise<SigResponse>;


### PR DESCRIPTION
## Goals

- Hide Pimlico API key, which is not meant for client distribution
- Track transaction reliability and performance
- Simplify configuration. Daimo app only uses a single API endpoint now, which makes it feasible to make this user-configurable like the RPC endpoint in traditional eth wallets, in the future.