### PR TITLE
workaround safe area view flicker bug

### DIFF
--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -1,4 +1,4 @@
-import { NavigationContainer } from "@react-navigation/native";
+import { DefaultTheme, NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -8,6 +8,7 @@ import { RpcProvider } from "./logic/trpc";
 import { useSyncChain } from "./sync/sync";
 import { TabNav } from "./view/TabNav";
 import { useInitNavLinks } from "./view/shared/nav";
+import { color } from "./view/shared/style";
 
 export default function App() {
   console.log("[APP] rendering");
@@ -21,9 +22,17 @@ export default function App() {
   // Load font to fix icons on Android
   useFonts({ Octicons: require("../assets/octicons.ttf") });
 
+  const whiteBgTheme = {
+    ...DefaultTheme,
+    colors: {
+      ...DefaultTheme.colors,
+      background: color.white,
+    },
+  };
+
   return (
     <RpcProvider>
-      <NavigationContainer>
+      <NavigationContainer theme={whiteBgTheme}>
         <AppBody />
       </NavigationContainer>
     </RpcProvider>

--- a/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
@@ -8,7 +8,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { SearchResults } from "./send/SearchTab";
 import { useWarmCache } from "../../action/useSendAsync";
@@ -30,6 +30,8 @@ export default function HomeScreen() {
 }
 
 function HomeScreenInner({ account }: { account: Account }) {
+  const insets = useSafeAreaInsets();
+
   console.log(
     `[HOME] rendering ${account.name}, ${account.recentTransfers.length} ops`
   );
@@ -59,7 +61,14 @@ function HomeScreenInner({ account }: { account: Account }) {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <SafeAreaView style={ss.container.screen}>
+      {/* We don't use SafeAreaView because it has a bug: 
+      https://github.com/software-mansion/react-native-screens/issues/1276 */}
+      <View
+        style={{
+          ...ss.container.screen,
+          paddingTop: insets.top,
+        }}
+      >
         <SearchHeader prefix={searchPrefix} setPrefix={setSearchPrefix} />
         {searchPrefix != null && <SearchResults prefix={searchPrefix} />}
         {searchPrefix == null && (
@@ -75,7 +84,7 @@ function HomeScreenInner({ account }: { account: Account }) {
             />
           </>
         )}
-      </SafeAreaView>
+      </View>
     </TouchableWithoutFeedback>
   );
 }

--- a/apps/daimo-mobile/src/view/screen/receive/OnrampCBPay.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/OnrampCBPay.tsx
@@ -1,7 +1,8 @@
 import { generateOnRampURL } from "@coinbase/cbpay-js";
 import { daimoChainFromId } from "@daimo/contract";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import { SafeAreaView } from "react-native";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
 
 import "react-native-url-polyfill/auto";
@@ -16,6 +17,8 @@ export function CBPayWebView({
   destAccount: Account;
   onExit: () => void;
 }) {
+  const insets = useSafeAreaInsets();
+
   const coinbaseURL = useMemo(
     () =>
       generateOnRampURL({
@@ -79,13 +82,19 @@ export function CBPayWebView({
   }, []);
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: color.white }}>
+    <View
+      style={{
+        paddingTop: insets.top,
+        flex: 1,
+        backgroundColor: color.white,
+      }}
+    >
       <WebView
         source={{ uri: coinbaseURL }}
         onMessage={onMessage}
         originWhitelist={["*"]}
       />
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
We can't use SafeAreaView because it has a bug:  https://github.com/software-mansion/react-native-screens/issues/1276
Using insets with padding a regular view seems to work.