### PR TITLE
Move invite codes to be server-side

### DIFF
--- a/packages/daimo-api/src/env.ts
+++ b/packages/daimo-api/src/env.ts
@@ -264,5 +264,6 @@ export type ReadOnlyContractType<TAbi extends Abi> = GetContractReturnType<
   PublicClient<Transport, Chain>
 >;
 
-export const DAIMO_INVITE_CODES =
-  process.env.DAIMO_INVITE_CODES || "zuconnect,devconnect";
+export const daimoInviteCodes = new Set(
+  (process.env.DAIMO_INVITE_CODES || "zuconnect,devconnect").split(",")
+);

--- a/packages/daimo-api/src/env.ts
+++ b/packages/daimo-api/src/env.ts
@@ -263,3 +263,6 @@ export type ReadOnlyContractType<TAbi extends Abi> = GetContractReturnType<
   TAbi,
   PublicClient<Transport, Chain>
 >;
+
+export const DAIMO_INVITE_CODES =
+  process.env.DAIMO_INVITE_CODES || "zuconnect,devconnect";

--- a/packages/daimo-api/src/pushNotifier.ts
+++ b/packages/daimo-api/src/pushNotifier.ts
@@ -280,7 +280,7 @@ export class PushNotifier {
   getPushMessagesFromKeyRotations(logs: SigningKeyAddedOrRemovedLog[]) {
     const messages: ExpoPushMessage[] = [];
     for (const log of logs) {
-      const addr = log.address;
+      const addr = getAddress(log.address);
       const keyLabel = getSlotLabel(log.args.keySlot);
 
       // Skip notifications for account creation

--- a/packages/daimo-api/src/router.ts
+++ b/packages/daimo-api/src/router.ts
@@ -16,7 +16,7 @@ import { NameRegistry } from "./contract/nameRegistry";
 import { NoteIndexer } from "./contract/noteIndexer";
 import { OpIndexer } from "./contract/opIndexer";
 import { Paymaster } from "./contract/paymaster";
-import { ViemClient } from "./env";
+import { DAIMO_INVITE_CODES, ViemClient } from "./env";
 import { PushNotifier } from "./pushNotifier";
 import { Telemetry, zUserAction } from "./telemetry";
 import { trpcT } from "./trpc";
@@ -193,6 +193,13 @@ export function createRouter(
       .mutation(async (opts) => {
         const recipient = getAddress(opts.input.recipient);
         return faucet.request(recipient);
+      }),
+
+    verifyInviteCode: publicProcedure
+      .input(z.object({ inviteCode: z.string() }))
+      .query(async (opts) => {
+        const { inviteCode } = opts.input;
+        return DAIMO_INVITE_CODES.split(",").includes(inviteCode);
       }),
   });
 }

--- a/packages/daimo-api/src/router.ts
+++ b/packages/daimo-api/src/router.ts
@@ -16,7 +16,7 @@ import { NameRegistry } from "./contract/nameRegistry";
 import { NoteIndexer } from "./contract/noteIndexer";
 import { OpIndexer } from "./contract/opIndexer";
 import { Paymaster } from "./contract/paymaster";
-import { DAIMO_INVITE_CODES, ViemClient } from "./env";
+import { daimoInviteCodes, ViemClient } from "./env";
 import { PushNotifier } from "./pushNotifier";
 import { Telemetry, zUserAction } from "./telemetry";
 import { trpcT } from "./trpc";
@@ -199,7 +199,7 @@ export function createRouter(
       .input(z.object({ inviteCode: z.string() }))
       .query(async (opts) => {
         const { inviteCode } = opts.input;
-        return DAIMO_INVITE_CODES.split(",").includes(inviteCode);
+        return daimoInviteCodes.has(inviteCode);
       }),
   });
 }

--- a/packages/daimo-api/test/pushNotifier.test.ts
+++ b/packages/daimo-api/test/pushNotifier.test.ts
@@ -2,7 +2,7 @@ import { DaimoLinkNote, EAccount } from "@daimo/common";
 import { DaimoNonceMetadata, DaimoNonceType } from "@daimo/userop";
 import assert from "node:assert";
 import test from "node:test";
-import { Address, Hex, numberToHex } from "viem";
+import { Address, Hex, getAddress, numberToHex } from "viem";
 
 import { TransferLog } from "../src/contract/coinIndexer";
 import {
@@ -14,9 +14,9 @@ import { NoteOpLog } from "../src/contract/noteIndexer";
 import { OpIndexer } from "../src/contract/opIndexer";
 import { PushNotifier } from "../src/pushNotifier";
 
-const addrAlice = "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b94";
-const addrBob = "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93";
-const addrCharlie = "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b95";
+const addrAlice = getAddress("0x061b0a794945fe0Ff4b764bfB926317f3cFc8b94");
+const addrBob = getAddress("0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93");
+const addrCharlie = getAddress("0x061b0a794945fe0Ff4b764bfB926317f3cFc8b95");
 
 test("PushNotifier", async () => {
   const pn = createNotifierAliceBob();


### PR DESCRIPTION
On local dev, before entering the full string "testnet" it will say "Offline?" since we don't run an API server with chainID 8453 but I think that's fine since it only affects us internally.

Also fix capitalisation bug in key rotation push notifier.