### PR TITLE
Retry backoff on wallet deploy tx

### DIFF
--- a/packages/daimo-api/src/api/deployWallet.ts
+++ b/packages/daimo-api/src/api/deployWallet.ts
@@ -4,7 +4,7 @@ import { Address, Hex, encodeFunctionData } from "viem";
 
 import { AccountFactory } from "../contract/accountFactory";
 import { NameRegistry } from "../contract/nameRegistry";
-import { chainConfig } from "../env";
+import { chainConfig, retryBackoff } from "../env";
 import { Telemetry } from "../telemetry";
 
 export async function deployWallet(
@@ -45,9 +45,15 @@ export async function deployWallet(
   const address = await accountFactory.getAddress(pubKeyHex, initCalls);
 
   console.log(`[API] Deploying account for ${name}, address ${address}`);
-  const deployReceipt = await accountFactory.deploy(pubKeyHex, initCalls);
+  const deployReceipt = await retryBackoff(
+    `deployWallet-${name}-${pubKeyHex}`,
+    async () => {
+      return accountFactory.deploy(pubKeyHex, initCalls);
+    },
+    5
+  );
 
-  // If it worked, cache the name<>address mapping immediately.
+  // If it worked, cache the name <> address mapping immediately.
   if (deployReceipt.status === "success") {
     nameReg.onSuccessfulRegister(name, address);
   } else {

--- a/packages/daimo-api/src/api/deployWallet.ts
+++ b/packages/daimo-api/src/api/deployWallet.ts
@@ -47,9 +47,7 @@ export async function deployWallet(
   console.log(`[API] Deploying account for ${name}, address ${address}`);
   const deployReceipt = await retryBackoff(
     `deployWallet-${name}-${pubKeyHex}`,
-    async () => {
-      return accountFactory.deploy(pubKeyHex, initCalls);
-    },
+    () => accountFactory.deploy(pubKeyHex, initCalls),
     5
   );
 

--- a/packages/daimo-api/src/env.ts
+++ b/packages/daimo-api/src/env.ts
@@ -239,9 +239,10 @@ function getFilterName(filter: LogFilter<any>) {
 
 export async function retryBackoff<T>(
   name: string,
-  fn: () => Promise<T>
+  fn: () => Promise<T>,
+  retryCount: number = 10
 ): Promise<T> {
-  for (let i = 1; i <= 10; i++) {
+  for (let i = 1; i <= retryCount; i++) {
     try {
       return await fn();
     } catch (e) {


### PR DESCRIPTION
Fixes the edge case where two `deployWallet` race and one fails due to bad nonce.

Verified fix by running create account simultaneously on sim and dev build:

<img width="900" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/0af00a7b-74de-4dd7-8fd0-1f1abf90ee6e">

Closes #382 