### PR TITLE
Fix history op wrongly syncing

### DIFF
--- a/apps/daimo-mobile/src/sync/sync.ts
+++ b/apps/daimo-mobile/src/sync/sync.ts
@@ -180,7 +180,7 @@ function applySync(account: Account, result: AccountHistoryResult): Account {
   // TODO: store validUntil directly on the op
   const stillPending = oldPending.filter(
     (t) =>
-      syncFindSameOp(t.opHash!, recentTransfers) == null &&
+      syncFindSameOp(t.opHash, recentTransfers) == null &&
       t.timestamp + SEND_DEADLINE_SECS > result.lastBlockTimestamp
   );
   recentTransfers.push(...stillPending);
@@ -238,9 +238,10 @@ function applySync(account: Account, result: AccountHistoryResult): Account {
 }
 
 export function syncFindSameOp(
-  opHash: Hex,
+  opHash: Hex | undefined,
   ops: TransferOpEvent[]
 ): TransferOpEvent | null {
+  if (opHash == null) return null;
   return ops.find((r) => opHash === r.opHash) || null;
 }
 

--- a/apps/daimo-mobile/src/sync/sync.ts
+++ b/apps/daimo-mobile/src/sync/sync.ts
@@ -8,6 +8,7 @@ import {
   guessTimestampFromNum,
 } from "@daimo/common";
 import { DaimoChain, daimoChainFromId } from "@daimo/contract";
+import { Hex } from "viem";
 
 import { getNetworkState, updateNetworkState } from "./networkState";
 import { SEND_DEADLINE_SECS } from "../action/useSendAsync";
@@ -179,7 +180,7 @@ function applySync(account: Account, result: AccountHistoryResult): Account {
   // TODO: store validUntil directly on the op
   const stillPending = oldPending.filter(
     (t) =>
-      syncFindSameOp(t, recentTransfers) == null &&
+      syncFindSameOp(t.opHash!, recentTransfers) == null &&
       t.timestamp + SEND_DEADLINE_SECS > result.lastBlockTimestamp
   );
   recentTransfers.push(...stillPending);
@@ -237,10 +238,10 @@ function applySync(account: Account, result: AccountHistoryResult): Account {
 }
 
 export function syncFindSameOp(
-  op: TransferOpEvent,
+  opHash: Hex,
   ops: TransferOpEvent[]
 ): TransferOpEvent | null {
-  return ops.find((r) => op.opHash === r.opHash) || null;
+  return ops.find((r) => opHash === r.opHash) || null;
 }
 
 /** Update contacts based on recent interactions */

--- a/apps/daimo-mobile/src/view/screen/HistoryOpScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HistoryOpScreen.tsx
@@ -51,9 +51,7 @@ function HistoryOpScreenInner({
   // A pending op always has an opHash (since its initiated by the user's
   // account).
   let { op } = route.params;
-  op = op.opHash
-    ? syncFindSameOp(op.opHash, account.recentTransfers) || op
-    : op;
+  op = syncFindSameOp(op.opHash, account.recentTransfers) || op;
 
   // If we sent a note, show the note screen.
   // TODO: annotate note info directly on op via sync

--- a/apps/daimo-mobile/src/view/screen/HistoryOpScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HistoryOpScreen.tsx
@@ -48,8 +48,12 @@ function HistoryOpScreenInner({
 }: Props & { account: Account }) {
   // Load the latest version of this op. If the user opens the detail screen
   // while the op is pending, and it confirms, the screen should update.
+  // A pending op always has an opHash (since its initiated by the user's
+  // account).
   let { op } = route.params;
-  op = syncFindSameOp(op, account.recentTransfers) || op;
+  op = op.opHash
+    ? syncFindSameOp(op.opHash, account.recentTransfers) || op
+    : op;
 
   // If we sent a note, show the note screen.
   // TODO: annotate note info directly on op via sync


### PR DESCRIPTION
Tested on sim.

In future we should take a pass at typing OpEvents better to prevent these.

This PR assumes no transfer page needs to be updated / can never be pending if it does not have an OpHash.