### PR TITLE
mobile: fix Android offline state, add fetch timeout

### DIFF
--- a/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
+++ b/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
@@ -1,5 +1,5 @@
 import Octicons from "@expo/vector-icons/Octicons";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import Spacer from "./Spacer";
@@ -22,8 +22,15 @@ export function OfflineHeader() {
     marginHorizontal: -16,
   } as const;
 
+  const isAndroid = Platform.OS === "android";
+
   return (
     <View style={style}>
+      {
+        isAndroid && (
+          <Spacer h={16} />
+        ) /* Some Androids have a camera excluded from the safe insets. */
+      }
       {isOffline && (
         <TextBody color={color.midnight}>
           <Octicons name="alert" size={14} />


### PR DESCRIPTION
# Before

Android "offline" label hidden behind the camera on Pixel 2. Camera apparently not included in `useSafeAreaInsets`

Android offline unreliable--`fetch()` default timeout is super long, 5 minutes in Chrome, so sync can take forever to fail

# After

- Added manual top padding for Android
- Added fetch timeout


## Offline

<img width="791" alt="Screenshot 2023-11-09 at 12 45 31" src="https://github.com/daimo-eth/daimo/assets/169280/970c22e1-b2b2-4a12-a7dc-45963cbe569f">

## Online

<img width="778" alt="Screenshot 2023-11-09 at 12 48 09" src="https://github.com/daimo-eth/daimo/assets/169280/b862ad5f-c6d7-4e79-ace5-697e7f71bb25">



