### PR TITLE
API: invite codes, auto-faucet

### DIFF
--- a/apps/daimo-mobile/src/action/useCreateAccount.ts
+++ b/apps/daimo-mobile/src/action/useCreateAccount.ts
@@ -11,6 +11,7 @@ import { defaultEnclaveKeyName, useAccount } from "../model/account";
 /** Deploys a new contract wallet and registers it under a given username. */
 export function useCreateAccount(
   name: string,
+  invCode: string,
   daimoChain: DaimoChain
 ): ActHandle {
   const [as, setAS] = useActStatus();
@@ -24,7 +25,7 @@ export function useCreateAccount(
   const exec = async () => {
     if (!pubKeyHex) return;
     setAS("loading", "Creating account...");
-    result.mutate({ name, pubKeyHex });
+    result.mutate({ name, pubKeyHex, invCode });
   };
 
   // Once account creation succeeds, save the account

--- a/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
@@ -1,8 +1,8 @@
-import { AddrLabel, assert } from "@daimo/common";
+import { assert } from "@daimo/common";
 import { ChainConfig, daimoChainFromId } from "@daimo/contract";
 import Octicons from "@expo/vector-icons/Octicons";
 import * as Clipboard from "expo-clipboard";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Linking,
   StyleSheet,
@@ -11,11 +11,10 @@ import {
   View,
 } from "react-native";
 import "react-native-url-polyfill/auto";
-import { Address, getAddress } from "viem";
 
 import { WithdrawScreen } from "./WithdrawScreen";
 import { env } from "../../../logic/env";
-import { Account, useAccount } from "../../../model/account";
+import { Account } from "../../../model/account";
 import { ButtonMed } from "../../shared/Button";
 import { CheckLabel } from "../../shared/Check";
 import { InfoBubble } from "../../shared/InfoBubble";
@@ -52,12 +51,12 @@ function DepositScreenInner({ account }: { account: Account }) {
 
   return (
     <View>
-      {testnet ? (
-        <TestnetFaucet account={account} recipient={account.address} />
-      ) : (
-        <OnrampsSection account={account} />
+      {!testnet && (
+        <>
+          <OnrampsSection account={account} />
+          <Spacer h={32} />
+        </>
       )}
-      <Spacer h={32} />
       <SendToAddressSection {...{ account, chainConfig }} />
     </View>
   );
@@ -129,90 +128,6 @@ function SendToAddressSection({
         <Spacer h={16} />
         <AddressCopier addr={account.address} disabled={!check1 || !check2} />
       </View>
-    </View>
-  );
-}
-
-/** Request token from testnet faucet. */
-function TestnetFaucet({
-  account,
-  recipient,
-}: {
-  account: Account;
-  recipient: Address;
-}) {
-  const [, setAccount] = useAccount();
-
-  const rpcHook = env(daimoChainFromId(account.homeChainId)).rpcHook;
-
-  const faucetStatus = rpcHook.testnetFaucetStatus.useQuery({ recipient });
-
-  const mutation = rpcHook.testnetRequestFaucet.useMutation();
-  const request = useCallback(() => {
-    mutation.mutate({ recipient });
-  }, [recipient]);
-
-  // Show faucet payment in history promptly
-  useEffect(() => {
-    if (!mutation.isSuccess) return;
-    const newAccount = {
-      ...account,
-      recentTransfers: [...account.recentTransfers, mutation.data],
-      namedAccounts: [
-        ...account.namedAccounts,
-        { addr: getAddress(mutation.data.from), label: AddrLabel.Faucet },
-      ],
-    };
-    setAccount(newAccount);
-  }, [mutation.isSuccess]);
-
-  // Display
-  let canRequest = false;
-  let buttonType = "primary" as "primary" | "success" | "danger";
-  let message = "Request $50 from faucet";
-  if (mutation.isLoading) {
-    message = "Loading...";
-  } else if (mutation.isSuccess) {
-    message = "Faucet payment sent";
-    buttonType = "success";
-  } else if (mutation.isError) {
-    message = "Error";
-    buttonType = "danger";
-  } else if (faucetStatus.isError) {
-    message = "Faucet unavailable";
-  } else if (faucetStatus.isSuccess) {
-    switch (faucetStatus.data) {
-      case "unavailable":
-        message = "Faucet unavailable";
-        break;
-      case "alreadyRequested":
-        message = "Requested";
-        break;
-      case "alreadySent":
-        message = "Faucet payment sent";
-        buttonType = "success";
-        break;
-      case "canRequest":
-        canRequest = true;
-        break;
-    }
-  }
-
-  return (
-    <View style={styles.callout}>
-      <TextPara>
-        <Octicons name="alert" size={16} color="black" />{" "}
-        <TextBold>Testnet account.</TextBold> Your account is on the{" "}
-        {env(daimoChainFromId(account.homeChainId)).chainConfig.chainL2.name}{" "}
-        testnet.
-      </TextPara>
-      <Spacer h={16} />
-      <ButtonMed
-        title={message}
-        onPress={request}
-        type={buttonType}
-        disabled={!canRequest}
-      />
     </View>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21866,6 +21866,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/random-word-slugs": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/random-word-slugs/-/random-word-slugs-0.1.7.tgz",
+      "integrity": "sha512-8cyzxOIDeLFvwSPTgCItMXHGT5ZPkjhuFKUTww06Xg1dNMXuGxIKlARvS7upk6JXIm41ZKXmtlKR1iCRWklKmg=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
@@ -26169,6 +26174,7 @@
         "geoip-lite": "^1.4.7",
         "libhoney": "^4.1.0",
         "pg": "^8.11.0",
+        "random-word-slugs": "^0.1.7",
         "userop": "^0.3.2",
         "viem": "^1.16.0",
         "zod": "^3.21.4"

--- a/packages/daimo-api/package.json
+++ b/packages/daimo-api/package.json
@@ -29,6 +29,7 @@
     "geoip-lite": "^1.4.7",
     "libhoney": "^4.1.0",
     "pg": "^8.11.0",
+    "random-word-slugs": "^0.1.7",
     "userop": "^0.3.2",
     "viem": "^1.16.0",
     "zod": "^3.21.4"

--- a/packages/daimo-api/src/contract/faucet.ts
+++ b/packages/daimo-api/src/contract/faucet.ts
@@ -10,9 +10,9 @@ import { ViemClient, chainConfig } from "../env";
 export type FaucetStatus =
   | "unavailable"
   | "canRequest"
-  | "alreadyRequested"
-  | "alreadySentInvite"
-  | "alreadySentAddress";
+  | "alreadyRequestedCoins"
+  | "alreadyUsedInvite"
+  | "alreadySentCoins";
 
 type InviteCodeStatus = {
   useCount: number;
@@ -65,10 +65,10 @@ export class Faucet {
   }
 
   getStatus(address: Address, invCode: string): FaucetStatus {
-    if (!this.verifyInviteCode(invCode)) return "alreadySentInvite";
+    if (!this.verifyInviteCode(invCode)) return "alreadyUsedInvite";
 
-    if (this.sent.has(address)) return "alreadySentAddress";
-    if (this.requested.has(address)) return "alreadyRequested";
+    if (this.sent.has(address)) return "alreadySentCoins";
+    if (this.requested.has(address)) return "alreadyRequestedCoins";
     return "canRequest";
   }
 

--- a/packages/daimo-api/src/contract/faucet.ts
+++ b/packages/daimo-api/src/contract/faucet.ts
@@ -1,25 +1,47 @@
-import { OpStatus, TransferOpEvent } from "@daimo/common";
+import { OpStatus, TransferOpEvent, dollarsToAmount } from "@daimo/common";
 import { erc20ABI } from "@daimo/contract";
+import { generateSlug } from "random-word-slugs";
 import { Address } from "viem";
 
 import { CoinIndexer, TransferLog } from "./coinIndexer";
+import { DB } from "../db/db";
 import { ViemClient, chainConfig } from "../env";
 
 export type FaucetStatus =
   | "unavailable"
   | "canRequest"
   | "alreadyRequested"
-  | "alreadySent";
+  | "alreadySentInvite"
+  | "alreadySentAddress";
+
+type InviteCodeStatus = {
+  useCount: number;
+  maxUses: number;
+};
 
 /** Testnet faucet. Drips testUSDC to any account not yet requested. */
 export class Faucet {
   private requested = new Set<Address>();
   private sent = new Set<Address>();
+  private inviteCodes = new Map<string, InviteCodeStatus>();
 
-  constructor(private vc: ViemClient, private coinIndexer: CoinIndexer) {}
+  constructor(
+    private vc: ViemClient,
+    private coinIndexer: CoinIndexer,
+    private db: DB
+  ) {}
 
   async init() {
     this.coinIndexer.pipeAllTransfers(this.parseLogs);
+
+    const rows = await this.db.loadInviteCodes();
+    console.log(`[PUSH] loaded ${rows.length} push tokens from DB`);
+    for (const row of rows) {
+      this.cacheInviteCode(row.code, {
+        useCount: row.useCount,
+        maxUses: row.maxUses,
+      });
+    }
   }
 
   parseLogs = (logs: TransferLog[]) => {
@@ -31,31 +53,65 @@ export class Faucet {
     }
   };
 
-  getStatus(address: Address): FaucetStatus {
-    if (!this.vc.walletClient.chain.testnet) return "unavailable";
-    if (this.sent.has(address)) return "alreadySent";
+  cacheInviteCode(code: string, status: InviteCodeStatus) {
+    this.inviteCodes.set(code, status);
+  }
+
+  verifyInviteCode(invCode: string): boolean {
+    if (!this.inviteCodes.has(invCode)) return false;
+    const { useCount, maxUses } = this.inviteCodes.get(invCode)!;
+    if (useCount >= maxUses) return false;
+    return true;
+  }
+
+  getStatus(address: Address, invCode: string): FaucetStatus {
+    if (!this.verifyInviteCode(invCode)) return "alreadySentInvite";
+
+    if (this.sent.has(address)) return "alreadySentAddress";
     if (this.requested.has(address)) return "alreadyRequested";
     return "canRequest";
   }
 
-  async request(address: Address): Promise<TransferOpEvent> {
-    const status = this.getStatus(address);
+  async incrementInviteCodeUseCount(code: string) {
+    await this.db.incrementInviteCodeUseCount(code);
+    this.inviteCodes.get(code)!.useCount += 1;
+  }
+
+  async saveInviteCode(code: string, status: InviteCodeStatus) {
+    await this.db.saveInviteCode({ code, ...status });
+    this.inviteCodes.set(code, status);
+  }
+
+  async createInviteCode(maxUses: number): Promise<string> {
+    const code = generateSlug(2, {
+      partsOfSpeech: ["adjective", "noun"],
+    }).toLowerCase();
+    await this.saveInviteCode(code, { useCount: 0, maxUses });
+    return code;
+  }
+
+  async request(
+    address: Address,
+    dollars: number,
+    invCode: string
+  ): Promise<TransferOpEvent> {
+    const status = this.getStatus(address, invCode);
     if (status !== "canRequest") throw new Error(status);
 
     this.requested.add(address);
+    await this.incrementInviteCodeUseCount(invCode);
 
-    console.log(`[FAUCET] sending 50 testUSDC to ${address}`);
-    const amount = 50_000_000n;
+    console.log(`[FAUCET] sending $${dollars} USDC to ${address}`);
     const hash = await this.vc.walletClient.writeContract({
       abi: erc20ABI,
       address: chainConfig.tokenAddress,
       functionName: "transfer",
-      args: [address, amount],
+      args: [address, dollarsToAmount(dollars)],
     });
 
     return {
       type: "transfer",
-      amount: Number(amount),
+      amount: Number(dollarsToAmount(dollars)),
       from: this.vc.walletClient.account.address,
       to: address,
       timestamp: Math.floor(Date.now() / 1e3),

--- a/packages/daimo-api/src/env.ts
+++ b/packages/daimo-api/src/env.ts
@@ -264,7 +264,3 @@ export type ReadOnlyContractType<TAbi extends Abi> = GetContractReturnType<
   TAbi,
   PublicClient<Transport, Chain>
 >;
-
-export const daimoInviteCodes = new Set(
-  (process.env.DAIMO_INVITE_CODES || "zuconnect,devconnect").split(",")
-);

--- a/packages/daimo-api/src/server.ts
+++ b/packages/daimo-api/src/server.ts
@@ -27,6 +27,10 @@ async function main() {
   await vc.init();
   const bundlerClient = getBundlerClientFromEnv();
 
+  console.log(`[API] initializing db...`);
+  const db = new DB();
+  await db.createTables();
+
   console.log(`[API] using wallet ${vc.walletClient.account.address}`);
   const keyReg = new KeyRegistry(vc);
   const nameReg = new NameRegistry(vc);
@@ -34,13 +38,9 @@ async function main() {
   const paymaster = new Paymaster(vc, bundlerClient);
   const coinIndexer = new CoinIndexer(vc, opIndexer);
   const noteIndexer = new NoteIndexer(vc, nameReg);
-  const faucet = new Faucet(vc, coinIndexer);
+  const faucet = new Faucet(vc, coinIndexer, db);
   const accountFactory = new AccountFactory(vc);
   const crontab = new Crontab(vc, coinIndexer, nameReg, monitor);
-
-  console.log(`[API] initializing db...`);
-  const db = new DB();
-  await db.createTables();
 
   const notifier = new PushNotifier(
     coinIndexer,

--- a/packages/daimo-common/src/model.ts
+++ b/packages/daimo-common/src/model.ts
@@ -9,7 +9,7 @@ export const zAddress = z
   .refine((s): s is Address => true);
 
 export enum AddrLabel {
-  Faucet = "faucet",
+  Faucet = "team daimo",
   PaymentLink = "payment link",
   Paymaster = "fee",
   Coinbase = "coinbase",


### PR DESCRIPTION
Repurposes Faucet to auto-send for invite code accounts.

Onboarding: Moves invite page after flow selection page. So now if we have to test Use Existing flow on testnet we need to first go into create account and enter a testnet invite code, we can make this better in future but this only affects us internally for testing so doing this for now.

new flow screenshots:

<img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/87122cf1-fb3c-46b0-800e-7875fe4bea87">
<img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/3f6c1296-6f46-4c83-ac22-e5226cdea91c">
<img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/b69b97c1-8107-4adb-81af-846ee8d3610a">


Slight copy updates, "faucet" -> "team daimo", "Use existing" -> "Already have an account?"