### PR TITLE
remove origin from raw sigs to reduce calldata

### DIFF
--- a/apps/daimo-mobile/src/action/useSendAsync.ts
+++ b/apps/daimo-mobile/src/action/useSendAsync.ts
@@ -153,7 +153,7 @@ function loadOpSender({
 
   const signer = usePasskey
     ? getWrappedPasskeySigner(daimoChain)
-    : getWrappedRawSigner(enclaveKeyName, keySlot!, daimoChain);
+    : getWrappedRawSigner(enclaveKeyName, keySlot!);
 
   const sender: OpSenderCallback = async (op: UserOpHex) => {
     return rpcFunc.sendUserOp.mutate({ op });

--- a/apps/daimo-mobile/src/logic/key.ts
+++ b/apps/daimo-mobile/src/logic/key.ts
@@ -1,5 +1,5 @@
 import { isDERPubKey, assert, parseAndNormalizeSig } from "@daimo/common";
-import { DaimoChain, daimoAccountABI } from "@daimo/contract";
+import { daimoAccountABI } from "@daimo/contract";
 import * as ExpoEnclave from "@daimo/expo-enclave";
 import { SigningCallback } from "@daimo/userop";
 import { base64urlnopad } from "@scure/base";
@@ -14,7 +14,6 @@ import {
   isHex,
 } from "viem";
 
-import { env } from "./env";
 import { Log } from "./log";
 
 // Parses the custom URI from the Add Device QR code.
@@ -36,8 +35,7 @@ export function createAddDeviceString(pubKey: Hex): string {
 // Unlike passkeys, which are backed up, enclave keys never leave the device.
 export function getWrappedRawSigner(
   enclaveKeyName: string,
-  keySlot: number,
-  daimoChain: DaimoChain
+  keySlot: number
 ): SigningCallback {
   return async (challengeHex: Hex) => {
     const bChallenge = hexToBytes(challengeHex);
@@ -46,7 +44,6 @@ export function getWrappedRawSigner(
     const clientDataJSON = JSON.stringify({
       type: "webauthn.get",
       challenge: challengeB64URL,
-      origin: env(daimoChain).passkeyDomain,
     });
 
     const clientDataHash = new Uint8Array(


### PR DESCRIPTION
saves a few cent per tx.

tested on mainnet.
before: https://basescan.org/tx/0x99596117a3f63f69cd29f36656f816b4f13370f07d77021347706a68a656868a
after: https://basescan.org/tx/0xc4fb21679d091a1ec87341a15cc141b5303c671043efdcdd1c856f31c558ae04

Thanks to Ansgar's analysis for discovering this.