### PR TITLE
api: fix CBPay asset filter

### DIFF
--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -125,7 +125,6 @@ function fetchRecommendedExchanges(account: EAccount): RecommendedExchange[] {
     destinationWallets: [
       {
         address: account.addr,
-        blockchains: ["base"],
         assets: ["USDC"],
         supportedNetworks: ["base"],
       },


### PR DESCRIPTION
From Carl Fluke at CB:

> Assets and Blockchains is an OR filter. If you remove blockchains, you should get what you are after.
