### PR TITLE
Send: no tab for links

### DIFF
--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -25,6 +25,7 @@ import OnboardingScreen from "./screen/onboarding/OnboardingScreen";
 import DepositScreen from "./screen/receive/DepositScreen";
 import ReceiveScreen from "./screen/receive/ReceiveScreen";
 import { SendNavScreen } from "./screen/send/SendNavScreen";
+import { SendNoteScreen } from "./screen/send/SendNoteScreen";
 import SendTransferScreen from "./screen/send/SendTransferScreen";
 import { OctName } from "./shared/InputBig";
 import {
@@ -139,6 +140,7 @@ function SendTab() {
         <SendStack.Screen name="SendNav" component={SendNavScreen} />
         <SendStack.Screen name="SendTransfer" component={SendTransferScreen} />
         <SendStack.Screen name="QR" component={QRScreen} />
+        <SendStack.Screen name="SendLink" component={SendNoteScreen} />
       </SendStack.Group>
     </SendStack.Navigator>
   );

--- a/apps/daimo-mobile/src/view/screen/send/SearchTab.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SearchTab.tsx
@@ -86,7 +86,7 @@ function SearchResultsScroll({
       keyboardShouldPersistTaps="handled"
     >
       {res.error && <ErrorRowCentered error={res.error} />}
-      {recentsOnly && <QRRow />}
+      {recentsOnly && <ExtraRows />}
       {res.recipients.length > 0 && (
         <View style={styles.resultsHeader}>
           <TextLight>
@@ -110,8 +110,7 @@ function NoSearchResults() {
   const nav = useNav();
   const sendPaymentLink = () =>
     nav.navigate("SendTab", {
-      screen: "SendNav",
-      params: { autoFocus: true, sendNote: true },
+      screen: "SendLink",
     });
 
   return (
@@ -161,25 +160,49 @@ function RecipientRow({ recipient }: { recipient: Recipient }) {
   );
 }
 
-function QRRow() {
+function ExtraRows() {
   const nav = useNav();
+
   return (
-    <Row
-      key="qrScan"
-      onPress={() =>
-        nav.navigate("SendTab", {
-          screen: "QR",
-          params: { option: "SCAN" },
-        })
-      }
-    >
+    <>
+      <ExtraRow
+        title="Send via link"
+        inside={<Octicons name="link" size={16} color={color.primary} />}
+        onPress={() =>
+          nav.navigate("SendTab", {
+            screen: "SendLink",
+          })
+        }
+      />
+      <ExtraRow
+        title="Scan QR code"
+        inside={<Octicons name="apps" size={16} color={color.primary} />}
+        onPress={() =>
+          nav.navigate("SendTab", {
+            screen: "QR",
+            params: { option: "SCAN" },
+          })
+        }
+      />
+    </>
+  );
+}
+
+function ExtraRow({
+  title,
+  inside,
+  onPress,
+}: {
+  title: string;
+  inside: React.JSX.Element;
+  onPress: () => void;
+}) {
+  return (
+    <Row key={title} onPress={onPress}>
       <View style={styles.resultRow}>
         <View style={styles.resultAccount}>
-          <Bubble
-            inside={<Octicons name="apps" size={16} color={color.primary} />}
-            size={36}
-          />
-          <TextBody>Scan QR code</TextBody>
+          <Bubble inside={inside} size={36} />
+          <TextBody>{title}</TextBody>
         </View>
       </View>
     </Row>

--- a/apps/daimo-mobile/src/view/screen/send/SendNavScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendNavScreen.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import {
   Keyboard,
   Platform,
@@ -10,9 +10,7 @@ import {
 import { TextInput } from "react-native-gesture-handler";
 
 import { SearchTab } from "./SearchTab";
-import { SendNoteScreen } from "./SendNoteScreen";
 import { ScreenHeader, useExitToHome } from "../../shared/ScreenHeader";
-import { SegmentSlider } from "../../shared/SegmentSlider";
 import Spacer from "../../shared/Spacer";
 import { ParamListSend, useNav } from "../../shared/nav";
 import { ss } from "../../shared/style";
@@ -37,18 +35,8 @@ export function SendNavScreen({ route }: Props) {
   );
 }
 
-type SendTab = "SEARCH" | "SEND LINK";
-
-function SendNav({
-  autoFocus,
-  sendNote,
-}: {
-  autoFocus: boolean;
-  sendNote?: boolean;
-}) {
+function SendNav({ autoFocus }: { autoFocus: boolean }) {
   // Navigation
-  const [tab, setTab] = useState<SendTab>(sendNote ? "SEND LINK" : "SEARCH");
-  const [tabs] = useState(["SEARCH", "SEND LINK"] as SendTab[]);
   const textInputRef = useRef<TextInput>(null);
   const isFocused = useIsFocused();
   const nav = useNav();
@@ -71,22 +59,9 @@ function SendNav({
     }
   }, [isFocused, autoFocus]);
 
-  // Hack: listen for prop changed due to navigation
-  const refSend = useRef(!!sendNote);
-  useEffect(() => {
-    if (!!sendNote === refSend.current) return;
-    setTab(sendNote ? "SEND LINK" : "SEARCH");
-    refSend.current = !!sendNote;
-  }, [sendNote]);
-
   return (
     <View style={{ flex: 1, flexDirection: "column" }}>
-      <SegmentSlider {...{ tabs, tab, setTab }} />
-      <Spacer h={24} />
-      {tab === "SEARCH" && (
-        <SearchTab {...{ autoFocus }} textInnerRef={textInputRef} />
-      )}
-      {tab === "SEND LINK" && <SendNoteScreen />}
+      <SearchTab {...{ autoFocus }} textInnerRef={textInputRef} />
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/screen/send/SendNoteScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendNoteScreen.tsx
@@ -1,11 +1,19 @@
 import { useCallback, useRef, useState } from "react";
-import { TextInput, View } from "react-native";
+import {
+  Keyboard,
+  TextInput,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
 
 import { SendNoteButton } from "./SendNoteButton";
 import { AmountChooser } from "../../shared/AmountInput";
 import { ButtonBig } from "../../shared/Button";
 import { InfoBubble } from "../../shared/InfoBubble";
+import { ScreenHeader, useExitToHome } from "../../shared/ScreenHeader";
 import Spacer from "../../shared/Spacer";
+import { useNav } from "../../shared/nav";
+import { ss } from "../../shared/style";
 import { TextCenter, TextLight } from "../../shared/text";
 
 export function SendNoteScreen() {
@@ -19,36 +27,43 @@ export function SendNoteScreen() {
     setAmountChosen(true);
   }, []);
 
+  const nav = useNav();
+  const goHome = useExitToHome();
+  const goBack = nav.canGoBack() ? nav.goBack : goHome;
+
   return (
-    <View>
-      <Spacer h={8} />
-      <InfoBubble
-        title="Pay by sending a link"
-        subtitle="Anyone with the link can claim it"
-      />
-      <Spacer h={32} />
-      <TextCenter>
-        <TextLight>Enter amount</TextLight>
-      </TextCenter>
-      <Spacer h={24} />
-      <AmountChooser
-        dollars={noteDollars}
-        onSetDollars={setNoteDollars}
-        showAmountAvailable={!amountChosen}
-        autoFocus
-        disabled={amountChosen}
-        innerRef={textInputRef}
-      />
-      <Spacer h={32} />
-      {!amountChosen && (
-        <ButtonBig
-          type="primary"
-          title="Create Payment Link"
-          disabled={!(noteDollars > 0)}
-          onPress={onChooseAmount}
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <View style={ss.container.screen}>
+        <ScreenHeader title="Send Link" onBack={goBack} />
+        <Spacer h={8} />
+        <InfoBubble
+          title="Pay by sending a link"
+          subtitle="Anyone with the link can claim it"
         />
-      )}
-      {amountChosen && <SendNoteButton dollars={noteDollars} />}
-    </View>
+        <Spacer h={32} />
+        <TextCenter>
+          <TextLight>Enter amount</TextLight>
+        </TextCenter>
+        <Spacer h={24} />
+        <AmountChooser
+          dollars={noteDollars}
+          onSetDollars={setNoteDollars}
+          showAmountAvailable={!amountChosen}
+          autoFocus
+          disabled={amountChosen}
+          innerRef={textInputRef}
+        />
+        <Spacer h={32} />
+        {!amountChosen && (
+          <ButtonBig
+            type="primary"
+            title="Create Payment Link"
+            disabled={!(noteDollars > 0)}
+            onPress={onChooseAmount}
+          />
+        )}
+        {amountChosen && <SendNoteButton dollars={noteDollars} />}
+      </View>
+    </TouchableWithoutFeedback>
   );
 }

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -27,6 +27,7 @@ export type ParamListSend = {
   SendNav: { autoFocus: boolean; sendNote?: boolean };
   SendTransfer: SendNavProp;
   QR: { option: QRScreenOptions | undefined };
+  SendLink: undefined;
 };
 
 export type ParamListReceive = {


### PR DESCRIPTION

https://github.com/daimo-eth/daimo/assets/6984346/8f988b15-1a69-4094-bae9-0a60eab67e98

Seeing Ibbi use the app / walking through what he was thinking seems like 1) having a tab for notes but not QR is unintuitive and 2) Having a search and Send link title makes it not obvious that both the tabs are for sending and not another action.

This seems like a clean solution. Thoughts?