### PR TITLE
api: add error logging, paymasterAndData sanity check

### DIFF
--- a/apps/daimo-mobile/src/sync/sync.ts
+++ b/apps/daimo-mobile/src/sync/sync.ts
@@ -139,6 +139,16 @@ async function fetchSync(
   };
   console.log(`[SYNC] got history ${JSON.stringify(syncSummary)}`);
 
+  // Validation
+  assert(result.address === account.address);
+  assert(result.sinceBlockNum === sinceBlockNum);
+  assert(result.lastBlock >= result.sinceBlockNum);
+  assert(result.lastBlockTimestamp > 0);
+  assert(
+    result.chainGasConstants.paymasterAddress.length % 2 === 0,
+    `invalid paymasterAndData ${result.chainGasConstants.paymasterAddress}`
+  );
+
   return result;
 }
 

--- a/packages/daimo-api/src/contract/paymaster.ts
+++ b/packages/daimo-api/src/contract/paymaster.ts
@@ -170,11 +170,15 @@ async function getPaymasterWithSignature(addr: Address): Promise<Hex> {
   console.log(`[PAYMASTER] sign ${ticketHex} with ${signer.address}`);
 
   const sig = await sign({ hash: ticketHash, privateKey: signerPrivateKey });
-  const sigHex = concatHex([toHex(sig.v, { size: 1 }), sig.r, sig.s]);
-  assert(hexToBytes(sigHex).length === 65, "paymaster: invalid sig length");
+  const sigHex = concatHex([
+    toHex(sig.v, { size: 1 }),
+    toHex(hexToBigInt(sig.r), { size: 32 }),
+    toHex(hexToBigInt(sig.s, { size: 32 })),
+  ]);
+  assert(sigHex.length === 65 * 2 + 2, "paymaster: invalid sig length");
 
   const ret = concatHex([daimoPaymasterAddress, sigHex, validUntilHex]);
-  assert(hexToBytes(ret).length === 91, "paymaster: invalid ret length");
+  assert(ret.length === 91 * 2 + 2, "paymaster: invalid ret length");
   return ret;
 }
 

--- a/packages/daimo-api/src/contract/paymaster.ts
+++ b/packages/daimo-api/src/contract/paymaster.ts
@@ -173,7 +173,9 @@ async function getPaymasterWithSignature(addr: Address): Promise<Hex> {
   const sigHex = concatHex([toHex(sig.v, { size: 1 }), sig.r, sig.s]);
   assert(hexToBytes(sigHex).length === 65, "paymaster: invalid sig length");
 
-  return concatHex([daimoPaymasterAddress, sigHex, validUntilHex]);
+  const ret = concatHex([daimoPaymasterAddress, sigHex, validUntilHex]);
+  assert(hexToBytes(ret).length === 91, "paymaster: invalid ret length");
+  return ret;
 }
 
 function getDummyOp(): UserOpHex {

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -6,7 +6,7 @@ import { Crontab } from "./cron";
 import { PushNotifier } from "./pushNotifier";
 import { createRouter } from "./router";
 import { Telemetry } from "./telemetry";
-import { createContext } from "./trpc";
+import { createContext, onTrpcError } from "./trpc";
 import { AccountFactory } from "../contract/accountFactory";
 import { CoinIndexer } from "../contract/coinIndexer";
 import { Faucet } from "../contract/faucet";
@@ -90,6 +90,7 @@ async function main() {
     middleware: cors(),
     router,
     createContext,
+    onError: onTrpcError,
   });
 
   const trpcPrefix = `/chain/${chainConfig.chainL2.id}/`;


### PR DESCRIPTION
Heisenbug that occurs whenever signature `r` or `s` starts with a hex 0, lovely

Fixed