### PR TITLE
Disable dev auto reopen suggested action

### DIFF
--- a/apps/daimo-mobile/src/view/shared/SuggestedActionBox.tsx
+++ b/apps/daimo-mobile/src/view/shared/SuggestedActionBox.tsx
@@ -94,11 +94,7 @@ export function SuggestedActionBox({ action }: { action: SuggestedAction }) {
 
   // Fade in/out
   useEffect(() => {
-    if (!isVisible) {
-      setTimeout(() => {
-        setIsVisible(true);
-      }, 2000);
-    } else {
+    if (isVisible) {
       y.value = withTiming(0);
       x.value = 0;
       opacity.value = withTiming(1);


### PR DESCRIPTION
This was mainly for the debug and development reasons to reopen modal repeatedly but was probably not noticeable in release since suggestedActions go away but still should be removed I think