### PR TITLE
Add long press button to confirm transaction

### DIFF
--- a/apps/daimo-mobile/src/view/screen/send/SendTransferButton.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendTransferButton.tsx
@@ -21,7 +21,7 @@ import {
 import { Account } from "../../../model/account";
 import { Recipient } from "../../../sync/recipients";
 import { getAmountText } from "../../shared/Amount";
-import { ButtonBig } from "../../shared/Button";
+import { LongPressBigButton } from "../../shared/Button";
 import { ButtonWithStatus } from "../../shared/ButtonWithStatus";
 import { navResetToHome, useNav } from "../../shared/nav";
 import { TextError } from "../../shared/text";
@@ -100,11 +100,12 @@ function SendTransferButtonInner({
       case "idle":
       case "error":
         return (
-          <ButtonBig
+          <LongPressBigButton
             title="CONFIRM AND SEND"
             onPress={disabled ? undefined : exec}
             type="primary"
             disabled={disabled}
+            duration={400}
           />
         );
       case "loading":

--- a/apps/daimo-mobile/src/view/shared/AnimatedCircle.tsx
+++ b/apps/daimo-mobile/src/view/shared/AnimatedCircle.tsx
@@ -11,6 +11,7 @@ import { color } from "./style";
 
 const ACircle = Animated.createAnimatedComponent(Circle);
 
+/** Animated circular progress bar. */
 export const AnimatedCircle = ({
   progress,
   size,
@@ -99,7 +100,6 @@ const styles = StyleSheet.create({
   },
   circleBehind: {
     position: "absolute",
-    transform: [{ rotate: "-90deg" }],
     opacity: 0.4,
   },
 });

--- a/apps/daimo-mobile/src/view/shared/AnimatedCircle.tsx
+++ b/apps/daimo-mobile/src/view/shared/AnimatedCircle.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import Animated, {
+  SharedValue,
+  useAnimatedProps,
+  useAnimatedStyle,
+} from "react-native-reanimated";
+import Svg, { Circle } from "react-native-svg";
+
+import { color } from "./style";
+
+const ACircle = Animated.createAnimatedComponent(Circle);
+
+export const AnimatedCircle = ({
+  progress,
+  size,
+  strokeWidth,
+}: {
+  progress: SharedValue<number>;
+  size: number;
+  strokeWidth: number;
+}) => {
+  const componentHeight = size * 2 + strokeWidth * 2;
+  const circleProps = useAnimatedProps(() => {
+    return {
+      strokeDashoffset:
+        -size * Math.PI * 2 - progress.value * -size * Math.PI * 2,
+    };
+  });
+
+  const wrapperStyle = useAnimatedStyle(() => {
+    return {
+      opacity: Math.min(1, progress.value * 2.5),
+      transform: [
+        {
+          scale: Math.min(1, 0.85 + progress.value * 0.15),
+        },
+      ],
+    };
+  });
+
+  return (
+    <Animated.View
+      style={[
+        styles.wrapper,
+        {
+          height: componentHeight,
+          width: componentHeight,
+        },
+        wrapperStyle,
+      ]}
+    >
+      <Svg
+        height={componentHeight}
+        width={componentHeight}
+        viewBox={`-${strokeWidth} -${strokeWidth} ${componentHeight} ${componentHeight}`}
+        style={styles.circle}
+      >
+        <ACircle
+          cx={size}
+          cy={size}
+          r={size}
+          stroke={color.white}
+          strokeWidth={strokeWidth}
+          fill="transparent"
+          strokeDasharray={500}
+          strokeDashoffset={0}
+          animatedProps={circleProps}
+        />
+      </Svg>
+      <Svg
+        height={componentHeight}
+        width={componentHeight}
+        viewBox={`-${strokeWidth} -${strokeWidth} ${componentHeight} ${componentHeight}`}
+        style={styles.circleBehind}
+      >
+        <ACircle
+          cx={size}
+          cy={size}
+          r={size}
+          stroke={color.white}
+          strokeWidth={strokeWidth}
+          fill="transparent"
+        />
+      </Svg>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "absolute",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  circle: {
+    position: "absolute",
+    transform: [{ rotate: "-90deg" }],
+  },
+  circleBehind: {
+    position: "absolute",
+    transform: [{ rotate: "-90deg" }],
+    opacity: 0.4,
+  },
+});


### PR DESCRIPTION
Add long press button to confirm transaction. Animation can be customized a little (duration, size of circle and width of stroke but I can add more)

iOS:

https://github.com/daimo-eth/daimo/assets/42337257/4cd911df-4254-442e-bdb5-5b0be50db8cc

Android

https://github.com/daimo-eth/daimo/assets/42337257/c61acbc9-ac34-44b3-bd9c-bc232fffece1

