### PR TITLE
daimo-api: fix duplicate during indexer init

### DIFF
--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -229,7 +229,7 @@ export class ViemClient {
     for (
       let fromBlock = startBlock;
       fromBlock < lastBlockNum;
-      fromBlock += step
+      fromBlock += step + 1n
     ) {
       let toBlock = fromBlock + step;
       if (toBlock > lastBlockNum) toBlock = lastBlockNum;


### PR DESCRIPTION
I noticed that the cached log files were organized by start and stop block. I also noticed that the start and stop blocks overlapped. For example:

```
logs-Transfer-5710000-5715000
logs-Transfer-5715000-5720000
```

I then explored these files to find the following:

```
cat logs-Transfer-5715000-5720000 | \
  jq 'map(select(.blockNumber == "5715000n")) | .[0].transactionHash'

"0x71093f5b99ff2f550face2ccf3ce994cc58ce604cd62ee59bd6c0970fbb11a34"

cat  logs-Transfer-5710000-5715000 | \
  jq 'map(select(.blockNumber == "5715000n")) | .[0].transactionHash'

"0x71093f5b99ff2f550face2ccf3ce994cc58ce604cd62ee59bd6c0970fbb11a34"
```

I don't think this problem exists after initialization since the tryProcessLogsToLatestBlock function uses the previous stop + 1 for the next start.

Which is what this commit is doing for the pipeLogs function.