### PR TITLE
Add support for tablets and resize app on Mac

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -22,7 +22,7 @@ export default {
     iosDisplayInForeground: true,
   },
   ios: {
-    supportsTablet: false,
+    supportsTablet: true,
     bundleIdentifier: IS_DEV ? "com.daimo.dev" : "com.daimo",
     buildNumber: `${BUILD_NUM}`,
     associatedDomains: [

--- a/apps/daimo-mobile/eas.json
+++ b/apps/daimo-mobile/eas.json
@@ -8,7 +8,8 @@
       "ios": {
         "buildConfiguration": "Debug",
         "resourceClass": "large",
-        "simulator": true
+        "simulator": true,
+        "supportsTablet": true
       },
       "env": {
         "DAIMO_DOMAIN": "daimo.com",
@@ -24,7 +25,8 @@
         "gradleCommand": ":app:assembleDebug"
       },
       "ios": {
-        "buildConfiguration": "Debug"
+        "buildConfiguration": "Debug",
+        "supportsTablet": true
       },
       "env": {
         "DAIMO_DOMAIN": "daimo.com",
@@ -35,6 +37,9 @@
     "prod": {
       "resourceClass": "large",
       "node": "20.3.0",
+      "ios": {
+        "supportsTablet": true
+      },
       "env": {
         "DAIMO_APP_API_URL_MAINNET": "https://daimo-api-prod.onrender.com",
         "DAIMO_APP_API_URL_TESTNET": "https://daimo-api-testnet.onrender.com",

--- a/apps/daimo-mobile/eas.json
+++ b/apps/daimo-mobile/eas.json
@@ -8,8 +8,7 @@
       "ios": {
         "buildConfiguration": "Debug",
         "resourceClass": "large",
-        "simulator": true,
-        "supportsTablet": true
+        "simulator": true
       },
       "env": {
         "DAIMO_DOMAIN": "daimo.com",
@@ -25,8 +24,7 @@
         "gradleCommand": ":app:assembleDebug"
       },
       "ios": {
-        "buildConfiguration": "Debug",
-        "supportsTablet": true
+        "buildConfiguration": "Debug"
       },
       "env": {
         "DAIMO_DOMAIN": "daimo.com",
@@ -37,9 +35,6 @@
     "prod": {
       "resourceClass": "large",
       "node": "20.3.0",
-      "ios": {
-        "supportsTablet": true
-      },
       "env": {
         "DAIMO_APP_API_URL_MAINNET": "https://daimo-api-prod.onrender.com",
         "DAIMO_APP_API_URL_TESTNET": "https://daimo-api-testnet.onrender.com",

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -6,7 +6,6 @@ import * as Notifications from "expo-notifications";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
-  Dimensions,
   Linking,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -195,6 +194,8 @@ function getNext(
   }
 }
 
+const AMOUNT_OF_SLIDES = 4;
+
 function IntroPages({ onNext }: { onNext: () => void }) {
   const [pageIndex, setPageIndex] = useState(0);
   const updatePageBubble = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -215,6 +216,7 @@ function IntroPages({ onNext }: { onNext: () => void }) {
         style={styles.introPageScroll}
         onScroll={updatePageBubble}
         scrollEventThrottle={32}
+        contentContainerStyle={{ width: `${AMOUNT_OF_SLIDES * 100}%` }}
       >
         <IntroPage title="Welcome to Daimo">
           <TextParagraph>
@@ -267,7 +269,14 @@ function IntroPage({
   children: ReactNode;
 }) {
   return (
-    <View style={styles.introPage}>
+    <View
+      style={[
+        styles.introPage,
+        {
+          width: `${100 / AMOUNT_OF_SLIDES}%`,
+        },
+      ]}
+    >
       <TextCenter>
         <TextH1>{title}</TextH1>
       </TextCenter>
@@ -588,8 +597,6 @@ function LoadingScreen({
   );
 }
 
-const screenDimensions = Dimensions.get("screen");
-
 const styles = StyleSheet.create({
   onboardingScreen: {
     flex: 1,
@@ -604,7 +611,6 @@ const styles = StyleSheet.create({
     flexGrow: 0,
   },
   introPage: {
-    width: screenDimensions.width,
     padding: 32,
   },
   introText: {

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -124,13 +124,13 @@ export default function OnboardingScreen({
         <UseExistingPage onNext={next} onPrev={prev} daimoChain={daimoChain} />
       )}
       {page === "new-allow-notifications" && (
-        <AllowNotifications onNext={next} />
+        <AllowNotificationsPage onNext={next} />
       )}
       {page === "existing-allow-notifications" && (
-        <AllowNotifications onNext={next} />
+        <AllowNotificationsPage onNext={next} />
       )}
       {page === "new-loading" && (
-        <LoadingScreen
+        <CreateAccountSpinnerPage
           loadingStatus={createStatus}
           loadingMessage={createMessage}
           onNext={next}
@@ -194,7 +194,38 @@ function getNext(
   }
 }
 
-const AMOUNT_OF_SLIDES = 4;
+const tokenSymbol = "USDC";
+const introPages = [
+  <IntroPage title="Welcome to Daimo">
+    <TextParagraph>
+      Daimo is a global payments app that runs on Ethereum. Send and receive
+      USDC on Base mainnet.
+    </TextParagraph>
+  </IntroPage>,
+  <IntroPage title={tokenSymbol}>
+    <TextParagraph>
+      You can send and receive money using the {tokenSymbol} stablecoin. 1{" "}
+      {tokenSymbol} is $1.
+    </TextParagraph>
+    <View style={ss.container.marginHNeg16}>
+      <InfoLink
+        url="https://www.circle.com/en/usdc"
+        title="Learn how it works here"
+      />
+    </View>
+  </IntroPage>,
+  <IntroPage title="Yours alone">
+    <TextParagraph>
+      Daimo stores money via cryptographic secrets. There's no bank.
+    </TextParagraph>
+  </IntroPage>,
+  <IntroPage title="On Ethereum">
+    <TextParagraph>
+      Daimo runs on Base, an Ethereum rollup. This lets you send money securely,
+      anywhere in the world.
+    </TextParagraph>
+  </IntroPage>,
+];
 
 function IntroPages({ onNext }: { onNext: () => void }) {
   const [pageIndex, setPageIndex] = useState(0);
@@ -203,8 +234,6 @@ function IntroPages({ onNext }: { onNext: () => void }) {
     const page = Math.round(contentOffset.x / layoutMeasurement.width);
     setPageIndex(page);
   };
-
-  const tokenSymbol = "USDC";
 
   return (
     <View style={styles.introPages}>
@@ -216,41 +245,19 @@ function IntroPages({ onNext }: { onNext: () => void }) {
         style={styles.introPageScroll}
         onScroll={updatePageBubble}
         scrollEventThrottle={32}
-        contentContainerStyle={{ width: `${AMOUNT_OF_SLIDES * 100}%` }}
+        contentContainerStyle={{ width: `${introPages.length * 100}%` }}
       >
-        <IntroPage title="Welcome to Daimo">
-          <TextParagraph>
-            Daimo is a global payments app that runs on Ethereum. Send and
-            receive USDC on Base mainnet.
-          </TextParagraph>
-        </IntroPage>
-        <IntroPage title={tokenSymbol}>
-          <TextParagraph>
-            You can send and receive money using the {tokenSymbol} stablecoin. 1{" "}
-            {tokenSymbol} is $1.
-          </TextParagraph>
-          <View style={ss.container.marginHNeg16}>
-            <InfoLink
-              url="https://www.circle.com/en/usdc"
-              title="Learn how it works here"
-            />
+        {introPages.map((page, i) => (
+          <View style={{ width: `${100 / introPages.length}%` }} key={i}>
+            {page}
           </View>
-        </IntroPage>
-        <IntroPage title="Yours alone">
-          <TextParagraph>
-            Daimo stores money via cryptographic secrets. There's no bank.
-          </TextParagraph>
-        </IntroPage>
-        <IntroPage title="On Ethereum">
-          <TextParagraph>
-            Daimo runs on Base, an Ethereum rollup. This lets you send money
-            securely, anywhere in the world.
-          </TextParagraph>
-        </IntroPage>
+        ))}
       </ScrollView>
       <Spacer h={32} />
-      <View style={styles.introButtonsWrap}>
-        <ButtonBig type="primary" title="Enter" onPress={onNext} />
+      <View style={styles.introButtonsCenter}>
+        <View style={styles.introButtonsWrap}>
+          <ButtonBig type="primary" title="Enter" onPress={onNext} />
+        </View>
       </View>
     </View>
   );
@@ -269,14 +276,7 @@ function IntroPage({
   children: ReactNode;
 }) {
   return (
-    <View
-      style={[
-        styles.introPage,
-        {
-          width: `${100 / AMOUNT_OF_SLIDES}%`,
-        },
-      ]}
-    >
+    <View style={styles.introPage}>
       <TextCenter>
         <TextH1>{title}</TextH1>
       </TextCenter>
@@ -522,7 +522,7 @@ function SetupKeyPage({
   );
 }
 
-function AllowNotifications({ onNext }: { onNext: () => void }) {
+function AllowNotificationsPage({ onNext }: { onNext: () => void }) {
   const requestPermission = async () => {
     if (!Device.isDevice) {
       window.alert("Push notifications unsupported in simulator.");
@@ -562,7 +562,7 @@ function AllowNotifications({ onNext }: { onNext: () => void }) {
   );
 }
 
-function LoadingScreen({
+function CreateAccountSpinnerPage({
   loadingStatus,
   loadingMessage,
   onNext,
@@ -612,13 +612,22 @@ const styles = StyleSheet.create({
   },
   introPage: {
     padding: 32,
+    maxWidth: 480,
+    alignSelf: "center",
   },
   introText: {
     ...ss.text.body,
     lineHeight: 24,
   },
-  introButtonsWrap: {
+  introButtonsCenter: {
     paddingHorizontal: 24,
+    alignSelf: "stretch",
+    flexDirection: "row",
+    justifyContent: "center",
+  },
+  introButtonsWrap: {
+    flexGrow: 1,
+    maxWidth: 480,
   },
   paddedPage: {
     paddingTop: 64,

--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -4,6 +4,7 @@ import {
   ReactNode,
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -44,9 +45,16 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
     const tabBarHeight = useTabBarHeight();
     const bottomRef = useRef<BottomSheet>(null);
 
-    const maxHeight = screenDimensions.height - ins.top - ins.bottom;
-    const posYMini = swipeHeight;
-    const posYFull = maxHeight - tabBarHeight;
+    const [posYMini, setPosYMini] = useState(swipeHeight);
+    const [posYFull, setPosYFull] = useState(
+      screenDimensions.height - ins.top - ins.bottom - tabBarHeight
+    );
+
+    useEffect(() => {
+      const maxHeightOffset = screenDimensions.height - ins.top - ins.bottom;
+      setPosYMini(swipeHeight);
+      setPosYFull(maxHeightOffset - tabBarHeight);
+    });
 
     const [isMini, setIsMini] = useState(true);
 

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -23,7 +23,7 @@ const poolConfig: PoolConfig = {
 
 export class Watcher {
   private latest = chainConfig.chainL2.testnet ? 8750000n : 5700000n;
-  private batchSize = 10000n;
+  private batchSize = 100000n;
 
   private indexers: indexer[] = [];
   private pg: Pool;


### PR DESCRIPTION
Allow tablets to be build and distributed for. Also fix scroll and keyboard handling when installed on Mac.

Allow resize of the window but unfortunately when scaled up it does animate in very choppy manner - I will try to fix it asap but think that it shouldn't be a blocker for whole app 

https://github.com/daimo-eth/daimo/assets/42337257/64c07144-335f-419c-a5ac-33e53cdb003b

