### PR TITLE
daimo-api: bugfix. return latest block for getAccountHistory

### DIFF
--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -15,6 +15,7 @@ import { KeyRegistry } from "../contract/keyRegistry";
 import { NameRegistry } from "../contract/nameRegistry";
 import { Paymaster } from "../contract/paymaster";
 import { ViemClient } from "../network/viemClient";
+import { Watcher } from "../shovel/watcher";
 
 export interface AccountHistoryResult {
   address: Address;
@@ -51,6 +52,7 @@ export interface SuggestedAction {
 export async function getAccountHistory(
   address: Address,
   sinceBlockNum: number,
+  watcher: Watcher,
   vc: ViemClient,
   coinIndexer: CoinIndexer,
   nameReg: NameRegistry,
@@ -73,7 +75,7 @@ export async function getAccountHistory(
   }
 
   // Get the latest block + current balance.
-  const lastBlk = vc.getLastBlock();
+  const lastBlk = await watcher.latestBlock();
   if (lastBlk == null) throw new Error("No latest block");
   const lastBlock = Number(lastBlk.number);
   const lastBlockTimestamp = Number(lastBlk.timestamp);

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -75,10 +75,10 @@ export async function getAccountHistory(
   }
 
   // Get the latest block + current balance.
-  const lastBlk = await watcher.latestBlock();
+  const lastBlk = watcher.latestBlock();
   if (lastBlk == null) throw new Error("No latest block");
   const lastBlock = Number(lastBlk.number);
-  const lastBlockTimestamp = Number(lastBlk.timestamp);
+  const lastBlockTimestamp = lastBlk.timestamp;
   const lastBalance = await coinIndexer.getBalanceAt(address, lastBlock);
 
   // TODO: get userops, including reverted ones. Show failed sends.

--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -20,8 +20,10 @@ import { OpIndexer } from "../contract/opIndexer";
 import { Paymaster } from "../contract/paymaster";
 import { BundlerClient } from "../network/bundlerClient";
 import { ViemClient } from "../network/viemClient";
+import { Watcher } from "../shovel/watcher";
 
 export function createRouter(
+  watcher: Watcher,
   vc: ViemClient,
   bundlerClient: BundlerClient,
   coinIndexer: CoinIndexer,
@@ -123,6 +125,7 @@ export function createRouter(
         return getAccountHistory(
           address,
           sinceBlockNum,
+          watcher,
           vc,
           coinIndexer,
           nameReg,

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -55,11 +55,12 @@ async function main() {
     db
   );
 
+  const shovelWatcher = new Watcher(vc);
+  shovelWatcher.add(nameReg, keyReg, coinIndexer, noteIndexer, opIndexer);
+
   // Initialize in background
   (async () => {
     console.log(`[API] initializing indexers...`);
-    const shovelWatcher = new Watcher();
-    shovelWatcher.add(nameReg, keyReg, coinIndexer, noteIndexer, opIndexer);
     await shovelWatcher.init();
     shovelWatcher.watch();
 
@@ -71,6 +72,7 @@ async function main() {
 
   console.log(`[API] serving...`);
   const router = createRouter(
+    shovelWatcher,
     vc,
     bundlerClient,
     coinIndexer,

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -55,7 +55,7 @@ async function main() {
     db
   );
 
-  const shovelWatcher = new Watcher(vc);
+  const shovelWatcher = new Watcher();
   shovelWatcher.add(nameReg, keyReg, coinIndexer, noteIndexer, opIndexer);
 
   // Initialize in background

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -1,5 +1,5 @@
+import { guessTimestampFromNum } from "@daimo/common";
 import { ClientConfig, Pool, PoolConfig } from "pg";
-import { Block } from "viem";
 
 import { chainConfig } from "../env";
 import { ViemClient } from "../network/viemClient";
@@ -24,30 +24,24 @@ const poolConfig: PoolConfig = {
 
 export class Watcher {
   private latest = chainConfig.chainL2.testnet ? 8750000n : 5700000n;
-  private latestCachedBlock: Block | undefined;
   private batchSize = 10000n;
-  private vc: ViemClient;
 
   private indexers: indexer[] = [];
   private pg: Pool;
 
-  constructor(vc: ViemClient) {
+  constructor() {
     this.pg = new Pool(poolConfig);
-    this.vc = vc;
   }
 
   add(...i: indexer[]) {
     this.indexers.push(...i);
   }
 
-  async latestBlock(): Promise<Block> {
-    if (this.latestCachedBlock?.number === this.latest) {
-      return this.latestCachedBlock;
-    }
-    this.latestCachedBlock = await this.vc.publicClient.getBlock({
-      blockNumber: this.latest,
-    });
-    return this.latestCachedBlock;
+  latestBlock(): { number: bigint; timestamp: number } {
+    return {
+      number: this.latest,
+      timestamp: guessTimestampFromNum(this.latest, chainConfig.daimoChain),
+    };
   }
 
   async init() {

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -2,7 +2,6 @@ import { guessTimestampFromNum } from "@daimo/common";
 import { ClientConfig, Pool, PoolConfig } from "pg";
 
 import { chainConfig } from "../env";
-import { ViemClient } from "../network/viemClient";
 
 interface indexer {
   load(pg: Pool, from: bigint, to: bigint): void | Promise<void>;

--- a/packages/daimo-api/test/dtest.ts
+++ b/packages/daimo-api/test/dtest.ts
@@ -16,7 +16,7 @@ async function main() {
   const keyReg = new KeyRegistry();
   const noteIndexer = new NoteIndexer(nameReg);
 
-  const shovelWatcher = new Watcher();
+  const shovelWatcher = new Watcher(vc);
   shovelWatcher.add(keyReg, nameReg, opIndexer, coinIndexer, noteIndexer);
 
   const { startBlock, lastBlockNum } = {

--- a/packages/daimo-api/test/dtest.ts
+++ b/packages/daimo-api/test/dtest.ts
@@ -16,7 +16,7 @@ async function main() {
   const keyReg = new KeyRegistry();
   const noteIndexer = new NoteIndexer(nameReg);
 
-  const shovelWatcher = new Watcher(vc);
+  const shovelWatcher = new Watcher();
   shovelWatcher.add(keyReg, nameReg, opIndexer, coinIndexer, noteIndexer);
 
   const { startBlock, lastBlockNum } = {


### PR DESCRIPTION
Prior to this commit, and prior to shovel, the getAccountHistory function would use the ViemClient to get the latest block. This assumed that the ViemClient would be updating its block. Now that we are using Watcher, ViemClient was no longer updating its block which means that it latest value was only set on startup and then never updated.

Now you can ask Watcher for the latest block. It makes an RPC request to get the block's timestamp. Ideally this should be in the shovel table but it's not. I'm going to fix shovel so that it stores the block timestamp on the task table so that the Watcher will have the timestamp whenever it has the number.