### PR TITLE
daimo-api: wait for deploy to be indexed

### DIFF
--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -168,6 +168,7 @@ export function createRouter(
           name,
           pubKeyHex,
           invCode,
+          watcher,
           nameReg,
           accountFactory,
           faucet,

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -44,10 +44,23 @@ export class Watcher {
   }
 
   async waitFor(blockNumber: bigint, tries: number): Promise<boolean> {
+    const t0 = Date.now();
     for (let i = 0; i < tries; i++) {
-      if (this.latest >= blockNumber) return true;
+      if (this.latest >= blockNumber) {
+        console.log(
+          `[SHOVEL] waiting for block ${blockNumber}, found after ${
+            Date.now() - t0
+          }ms`
+        );
+        return true;
+      }
       await new Promise((res) => setTimeout(res, 250));
     }
+    console.log(
+      `[SHOVEL] waiting for block ${blockNumber}, NOT FOUND, still on ${
+        this.latest
+      } after ${Date.now() - t0}ms`
+    );
     return false;
   }
 

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -43,6 +43,14 @@ export class Watcher {
     };
   }
 
+  async waitFor(blockNumber: bigint, tries: number): Promise<boolean> {
+    for (let i = 0; i < tries; i++) {
+      if (this.latest >= blockNumber) return true;
+      await new Promise((res) => setTimeout(res, 250));
+    }
+    return false;
+  }
+
   async init() {
     await this.indexRange(this.latest, await this.getShovelLatest());
   }


### PR DESCRIPTION
I'm 50/50 on this change. I don't like that it adds a delay in the signup process. But it avoids hitting an error (silent?) when the user signs up and their keys have not been indexed.

The alternative is that we remove the assert and instead return some kind of empty result for getAccountHistory until the user's data has been indexed.

https://github.com/daimo-eth/daimo/blob/master/packages/daimo-api/src/api/getAccountHistory.ts#L107-L108