### PR TITLE
daimo-api: fix account pubkey

### DIFF
--- a/packages/daimo-api/src/contract/keyRegistry.ts
+++ b/packages/daimo-api/src/contract/keyRegistry.ts
@@ -114,7 +114,7 @@ export class KeyRegistry {
           log_addr,
           account,
           key_slot,
-          array_agg(key) as key
+          array_agg(key order by abi_idx asc) as key
         from ${table}
         where block_num >= $1 and block_num <= $2
         and chain_id = $3


### PR DESCRIPTION
Prior to this commit, we were leaving the order of keys returned from key_{added,removed} undefined. I guess it worked for a while, but in testing I found that the getAccountHistory endpoint was returning invalid keys. Now that the order is defined, the contractFriendlyKeyToDER function should produce correct results.