### PR TITLE
api: sort transaction index for key rotations within block

### DIFF
--- a/packages/daimo-api/src/contract/keyRegistry.ts
+++ b/packages/daimo-api/src/contract/keyRegistry.ts
@@ -37,6 +37,8 @@ export class KeyRegistry {
     changes!.sort((a, b) => {
       const bdiff = a.blockNumber - b.blockNumber;
       if (bdiff !== 0n) return Number(bdiff);
+      const tdiff = a.transactionIndex - b.transactionIndex;
+      if (tdiff !== 0) return tdiff;
       return a.logIndex - b.logIndex;
     });
     for (const change of changes) {


### PR DESCRIPTION
Subtle ordering bug if two userops make it into the same block.