### PR TITLE
Add X to go back to home from send flow

### DIFF
--- a/apps/daimo-mobile/src/view/screen/send/SendNoteScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendNoteScreen.tsx
@@ -40,7 +40,7 @@ export function SendNoteScreen({ route }: Props) {
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
       <View style={ss.container.screen}>
-        <ScreenHeader title="Send Link" onBack={goBack} />
+        <ScreenHeader title="Send Link" onBack={goBack} onExit={goHome} />
         <Spacer h={8} />
         <InfoBox
           title="Pay by sending a link"

--- a/apps/daimo-mobile/src/view/screen/send/SendTransferScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendTransferScreen.tsx
@@ -24,7 +24,7 @@ import { AmountChooser } from "../../shared/AmountInput";
 import { ButtonBig } from "../../shared/Button";
 import { ButtonCircle } from "../../shared/ButtonCircle";
 import { InfoBox } from "../../shared/InfoBox";
-import { ScreenHeader } from "../../shared/ScreenHeader";
+import { ScreenHeader, useExitToHome } from "../../shared/ScreenHeader";
 import Spacer from "../../shared/Spacer";
 import { ErrorRowCentered } from "../../shared/error";
 import {
@@ -52,13 +52,14 @@ export default function SendScreen({ route }: Props) {
     else if (nav.canGoBack()) nav.goBack();
     else navResetToHome(nav);
   }, [nav, dollars, recipient]);
+  const goHome = useExitToHome();
 
   useDisableTabSwipe(nav);
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
       <View style={ss.container.screen}>
-        <ScreenHeader title="Send to" onBack={goBack} />
+        <ScreenHeader title="Send to" onBack={goBack} onExit={goHome} />
         <Spacer h={8} />
         {!recipient && link && <SendLoadRecipient {...{ link }} />}
         {recipient && dollars == null && (
@@ -258,10 +259,7 @@ function RecipientDisplay({
 
   const nav = useNav();
   const goToAccount = useCallback(() => {
-    nav.navigate("SendTab", {
-      screen: "Account",
-      params: { eAcc: recipient },
-    });
+    nav.navigate("SendTab", { screen: "Account", params: { eAcc: recipient } });
   }, [nav, recipient]);
 
   return (


### PR DESCRIPTION
Just used `navResetToHome` func to go back.

Every time we use navResetToHome it blinks a little creating ugly effect that is much more visible on Android. I think we need to find some more elegant way to handle navigation reset. (Will try to investigate that now but since this is not a part of [this issue](https://github.com/daimo-eth/daimo/issues/513), it should be a separate PR)

iOS: 

https://github.com/daimo-eth/daimo/assets/42337257/eb38f0d9-0dcc-4c29-9dc0-e29c9257098e

Android:

https://github.com/daimo-eth/daimo/assets/42337257/30942acd-85ee-460a-b604-5c0ebc434798

