### PR TITLE
api: fix spread operator stack size exceeded

### DIFF
--- a/packages/daimo-api/src/contract/coinIndexer.ts
+++ b/packages/daimo-api/src/contract/coinIndexer.ts
@@ -87,7 +87,7 @@ export class CoinIndexer {
         Date.now() - startTime
       }ms`
     );
-    this.allTransfers.push(...logs);
+    this.allTransfers = this.allTransfers.concat(logs);
     this.listeners.forEach((l) => l(logs));
   }
 


### PR DESCRIPTION
Prod build has been failing for the last ~12 hours due https://github.com/daimo-eth/daimo/issues/366

Doesn't affect any services since Render continues using the old successful build.