### PR TITLE
release: 1.4.8

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -1,7 +1,7 @@
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.4.7";
-const BUILD_NUM = 94;
+const VERSION = "1.4.8";
+const BUILD_NUM = 95;
 
 export default {
   owner: "daimo",

--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -1,7 +1,7 @@
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
 const VERSION = "1.4.8";
-const BUILD_NUM = 95;
+const BUILD_NUM = 96;
 
 export default {
   owner: "daimo",
@@ -92,7 +92,7 @@ export default {
           kotlinVersion: "1.8.0",
         },
         ios: {
-          deploymentTarget: "15.0",
+          deploymentTarget: "15.8",
         },
       },
     ],

--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -22,7 +22,6 @@ export default {
     iosDisplayInForeground: true,
   },
   ios: {
-    supportsTablet: true,
     bundleIdentifier: IS_DEV ? "com.daimo.dev" : "com.daimo",
     buildNumber: `${BUILD_NUM}`,
     associatedDomains: [


### PR DESCRIPTION

**Remove iPad support.** We only added it to make the macOS app better, and in fact it made the macOS app worse. Also, it introduced a requirement for iPad screenshots. Removing.

<!-- Optional screenshot, 4-6 panels joined as described in scratchpad README. -->

## Release checklist

Abbreviated release testing, since the diff is minimal.


### Push to prod

- [x] Push to `prod`
- [ ] Prod API deploys correctly
- [ ] Prod website deploys correctly
- [ ] Logs clean
- [ ] Honeycomb clean

### Prod smoke test

- [ ] Log back into prod account
- [ ] Send a transfer
- [ ] Notification appears on confirmation
- [ ] Create Payment Link, open in browser.
- [ ] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [ ] Tap link. Ensure opens in app, status shows correctly.

### Promote release

BEFORE merging this PR,

- [ ] Push to public TestFlight + Play Store open test track.

