### PR TITLE
Add pointer events wrapper around debug modal

### DIFF
--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -66,7 +66,6 @@ function AppBody() {
   useEffect(() => {
     const subscription = RNShake.addListener(() => {
       bottomSheetRef.current?.expand();
-      setIsDebugModalOpen(true);
     });
 
     return () => {
@@ -86,11 +85,7 @@ function AppBody() {
     []
   );
 
-  const onChangeIndex = (index: number) => {
-    if (index === -1) {
-      setIsDebugModalOpen(false);
-    }
-  };
+  const onChangeIndex = (index: number) => setIsDebugModalOpen(index > -1);
 
   const [sendDL] = useSendDebugLog();
 

--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -4,7 +4,7 @@ import { DefaultTheme, NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -59,12 +59,14 @@ export default function App() {
 
 function AppBody() {
   const bottomSheetRef = useRef<BottomSheet>(null);
+  const [isDebugModalOpen, setIsDebugModalOpen] = useState(false);
 
   const snapPoints = useMemo(() => ["33%"], []);
 
   useEffect(() => {
     const subscription = RNShake.addListener(() => {
       bottomSheetRef.current?.expand();
+      setIsDebugModalOpen(true);
     });
 
     return () => {
@@ -76,7 +78,7 @@ function AppBody() {
     (props: BottomSheetDefaultBackdropProps) => (
       <BottomSheetBackdrop
         {...props}
-        disappearsOnIndex={-1}
+        disappearsOnIndex={-0.9}
         appearsOnIndex={0}
         pressBehavior="close"
       />
@@ -84,29 +86,41 @@ function AppBody() {
     []
   );
 
+  const onChangeIndex = (index: number) => {
+    if (index === -1) {
+      setIsDebugModalOpen(false);
+    }
+  };
+
   const [sendDL] = useSendDebugLog();
 
   return (
     <SafeAreaProvider>
       <TabNav />
       <StatusBar style="auto" />
-      <BottomSheet
-        handleComponent={ScrollPellet}
-        backdropComponent={renderBackdrop}
-        ref={bottomSheetRef}
-        index={-1}
-        snapPoints={snapPoints}
-        enablePanDownToClose
+      <View
+        style={styles.bottomSheetWrapper}
+        pointerEvents={isDebugModalOpen ? "auto" : "none"}
       >
-        <View style={styles.contentContainer}>
-          <Spacer h={16} />
-          <TextH3>Did something go wrong?</TextH3>
-          <Spacer h={12} />
-          <TextLight>Help us realize what's going wrong.</TextLight>
-          <Spacer h={32} />
-          <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
-        </View>
-      </BottomSheet>
+        <BottomSheet
+          handleComponent={ScrollPellet}
+          backdropComponent={renderBackdrop}
+          ref={bottomSheetRef}
+          index={-1}
+          snapPoints={snapPoints}
+          onChange={onChangeIndex}
+          enablePanDownToClose
+        >
+          <View style={styles.contentContainer}>
+            <Spacer h={16} />
+            <TextH3>Did something go wrong?</TextH3>
+            <Spacer h={12} />
+            <TextLight>Help us realize what's going wrong.</TextLight>
+            <Spacer h={32} />
+            <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
+          </View>
+        </BottomSheet>
+      </View>
     </SafeAreaProvider>
   );
 }
@@ -116,5 +130,10 @@ const styles = StyleSheet.create({
     flex: 1,
     alignSelf: "center",
     alignItems: "stretch",
+  },
+  bottomSheetWrapper: {
+    position: "absolute",
+    height: "100%",
+    width: "100%",
   },
 });


### PR DESCRIPTION
Added wrapper with dynamic state-based pointerEvents prop to make sure that debug modal doesn't prevent interactions even if invisible. 

Android:

https://github.com/daimo-eth/daimo/assets/42337257/4e9ef637-ead6-4824-967c-a4a9866a4b00

iOS: 

https://github.com/daimo-eth/daimo/assets/42337257/72da12f5-c85e-457f-bd01-3be2d417a8cd

