### PR TITLE
perf: refresh history list only on change

### DIFF
--- a/apps/daimo-mobile/src/view/shared/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/shared/HistoryList.tsx
@@ -56,6 +56,7 @@ export function HistoryListSwipe({
       return from === otherAddr || to === otherAddr;
     });
   }
+  console.log(`[HIST] HistoryListSwipe ${account.name}, ${ops.length} ops}`);
 
   // Link to either the op (zoomed in) or the other account (zoomed out)
   // const linkTo = "op"; // Option to link to AccountPage instead.


### PR DESCRIPTION
Before it refreshed all list every time something called resync(), so every 5 seconds or even more often

iOS:

https://github.com/daimo-eth/daimo/assets/42337257/f1634164-d480-44f6-9071-61058af42ad8

Android:

https://github.com/daimo-eth/daimo/assets/42337257/db11b53c-7741-4755-ae1f-c65b6359035c

