### PR TITLE
Make long press mandatory on confirm transaction

### DIFF
--- a/apps/daimo-mobile/src/view/shared/Button.tsx
+++ b/apps/daimo-mobile/src/view/shared/Button.tsx
@@ -52,8 +52,10 @@ export function LongPressBigButton(props: LongPressButtonProps) {
     .enabled(!props.disabled || false)
     .onBegin(() => {
       buttonScale.value = withTiming(0.97, { duration: props.duration }, () => {
-        console.log("[BUTTON] LongPresButton pressed");
-        props.onPress && runOnJS(props.onPress)();
+        if (buttonScale.value === 0.97) {
+          console.log("[BUTTON] LongPresButton pressed");
+          props.onPress && runOnJS(props.onPress)();
+        }
       });
       animatedCircleProgress.value = withTiming(1, {
         duration: props.duration,


### PR DESCRIPTION
I realised that it was enough to tap on long press transaction button to make it work.
Now it check if the animation was played all the way to the end before call `onPress`

iOS

https://github.com/daimo-eth/daimo/assets/42337257/d18064f6-43c1-48ff-a770-d16d0b47c850


Android:

https://github.com/daimo-eth/daimo/assets/42337257/52895962-a64e-4ff4-a174-de3950c3d298

