### PR TITLE
Delay focus when go to send screen from account screen

### DIFF
--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -111,7 +111,10 @@ function AccountScreenBody({
   const canSend = canSendTo(eAcc);
   const send = useCallback(() => {
     const recipient = addLastSendTime(account, eAcc);
-    nav.navigate("SendTab", { screen: "SendTransfer", params: { recipient } });
+    nav.navigate("SendTab", {
+      screen: "SendTransfer",
+      params: { recipient, lagAutoFocus: true },
+    });
   }, [nav, eAcc, account]);
 
   // Bottom sheet: show transactions between us and this account


### PR DESCRIPTION
Keyboard focus was broken when going to send screen from account screen. 
It opens correctly now

Closes #541

Android:

https://github.com/daimo-eth/daimo/assets/42337257/ceddb83c-a2b9-4050-97b4-8a23a4962b57

iOS:

https://github.com/daimo-eth/daimo/assets/42337257/54fd33eb-078c-411e-b639-7649fc9f1fdc

