### PR TITLE
mobile: change passkey display title

### DIFF
--- a/apps/daimo-mobile/src/logic/passkey.ts
+++ b/apps/daimo-mobile/src/logic/passkey.ts
@@ -28,9 +28,11 @@ export async function createPasskey(
     env(daimoChain).passkeyDomain
   );
   const passkeyName = `${accountName}.${keySlot}`;
-  const passkeyDisplayTitle = `${accountName} ${getSlotLabel(
-    keySlot
-  ).toLowerCase()}`; // Don't show metadata to the user
+
+  // Display title shows lowercase slot name, eg "alice passkey backup"
+  const slotLabel = getSlotLabel(keySlot).toLowerCase();
+  const passkeyDisplayTitle = `${accountName} ${slotLabel}`;
+
   const challengeB64 = btoa(`create key ${accountName} ${keySlot}`);
 
   const result = await Log.promise(

--- a/apps/daimo-mobile/src/logic/passkey.ts
+++ b/apps/daimo-mobile/src/logic/passkey.ts
@@ -1,4 +1,4 @@
-import { parseAndNormalizeSig } from "@daimo/common";
+import { getSlotLabel, parseAndNormalizeSig } from "@daimo/common";
 import { DaimoChain, daimoAccountABI } from "@daimo/contract";
 import * as ExpoPasskeys from "@daimo/expo-passkeys";
 import { SigningCallback } from "@daimo/userop";
@@ -28,7 +28,9 @@ export async function createPasskey(
     env(daimoChain).passkeyDomain
   );
   const passkeyName = `${accountName}.${keySlot}`;
-  const passkeyDisplayTitle = accountName; // Don't show metadata to the user
+  const passkeyDisplayTitle = `${accountName} ${getSlotLabel(
+    keySlot
+  ).toLowerCase()}`; // Don't show metadata to the user
   const challengeB64 = btoa(`create key ${accountName} ${keySlot}`);
 
   const result = await Log.promise(


### PR DESCRIPTION
Tested on iOS and Android:

<img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/2c58306b-1bae-4f2c-8fa8-55ce6986a968"/> <img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/73485c51-1cd1-47d1-b371-eba0df856a2c"/>

Android:

<img width="256" src="https://github.com/daimo-eth/daimo/assets/6984346/9f4bf137-bc60-400c-b6b6-da8ec25d6a2b"/> 
