### PR TITLE
Add activate offset to bottom sheet to allow back swipe

### DIFF
--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -1,4 +1,7 @@
-import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  SCREEN_WIDTH,
+} from "@gorhom/bottom-sheet";
 import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types";
 import {
   ReactNode,
@@ -123,6 +126,8 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
         enablePanDownToClose={false}
         enableHandlePanningGesture={!disabled}
         enableContentPanningGesture={!disabled}
+        activeOffsetX={[-1, SCREEN_WIDTH]}
+        activeOffsetY={[-10, 10]}
       >
         <Animated.View
           style={[styles.itemMiniWrapper, itemMiniStyle]}

--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -126,7 +126,7 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
         enablePanDownToClose={false}
         enableHandlePanningGesture={!disabled}
         enableContentPanningGesture={!disabled}
-        activeOffsetX={[-1, SCREEN_WIDTH]}
+        activeOffsetX={[-SCREEN_WIDTH, SCREEN_WIDTH]}
         activeOffsetY={[-10, 10]}
       >
         <Animated.View


### PR DESCRIPTION
Closes #551

Just like title: Allow to swipe left and right on home screen and back swipe on Account screen

iOS: (Sorry for no back interaction but it works well on physical device but doesn't seem to work at all on my simulator)

https://github.com/daimo-eth/daimo/assets/42337257/5a97c4e4-3525-4236-9433-5d0772465595

Android:

https://github.com/daimo-eth/daimo/assets/42337257/e3800d6c-7c6b-40cb-a5ed-f82d9580d54c

