### PR TITLE
mobile: Add NFC tag deeplinks

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -67,6 +67,18 @@ export default {
         ],
         category: ["BROWSABLE", "DEFAULT"],
       },
+      {
+        action: "NDEF_DISCOVERED",
+        autoVerify: true,
+        data: [
+          {
+            scheme: "https",
+            host: "daimo.com",
+            pathPrefix: "/link",
+          },
+        ],
+        category: ["BROWSABLE", "DEFAULT"],
+      },
     ],
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",
@@ -119,6 +131,7 @@ export default {
           "Allows Daimo to find and pay your friends. Your contacts remain private and are never uploaded or shared.",
       },
     ],
+    ["react-native-nfc-manager"],
     ["./android-deeplink-config-plugin", "custom"],
   ],
 };

--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -79,6 +79,30 @@ export default {
         ],
         category: ["BROWSABLE", "DEFAULT"],
       },
+      {
+        action: "VIEW",
+        autoVerify: true,
+        data: [
+          {
+            scheme: "https",
+            host: "daimo.com",
+            pathPrefix: "/l",
+          },
+        ],
+        category: ["BROWSABLE", "DEFAULT"],
+      },
+      {
+        action: "NDEF_DISCOVERED",
+        autoVerify: true,
+        data: [
+          {
+            scheme: "https",
+            host: "daimo.com",
+            pathPrefix: "/l",
+          },
+        ],
+        category: ["BROWSABLE", "DEFAULT"],
+      },
     ],
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",

--- a/apps/daimo-mobile/package.json
+++ b/apps/daimo-mobile/package.json
@@ -80,6 +80,7 @@
     "react-native-gesture-handler": "~2.12.0",
     "react-native-get-random-values": "~1.9.0",
     "react-native-mmkv": "^2.8.0",
+    "react-native-nfc-manager": "^3.14.12",
     "react-native-pager-view": "^6.2.2",
     "react-native-qrcode-svg": "^6.2.0",
     "react-native-reanimated": "~3.3.0",

--- a/apps/daimo-mobile/src/logic/deeplink.ts
+++ b/apps/daimo-mobile/src/logic/deeplink.ts
@@ -1,0 +1,29 @@
+import { getInitialURL } from "expo-linking";
+import { Platform } from "react-native";
+import NfcManager, { Ndef } from "react-native-nfc-manager";
+
+export async function getInitialURLOrTag() {
+  const url = await getInitialURL();
+  if (url) return url;
+
+  if (Platform.OS === "android") {
+    const tag = await NfcManager.getLaunchTagEvent();
+    if (tag && tag.ndefMessage.length > 0) {
+      console.log(`[DEEPLINK] got NFC tag ${JSON.stringify(tag)}`);
+      try {
+        const message = tag.ndefMessage[0];
+        const url = Ndef.uri.decodePayload(
+          message.payload as unknown as Uint8Array
+        );
+        console.log(`[DEEPLINK] decoded NFC tag payload: ${url}`);
+        return url;
+      } catch (e) {
+        console.warn(
+          `[DEEPLINK] error decoding NFC tag payload, failing silently: ${e}`
+        );
+      }
+    }
+  }
+
+  return null;
+}

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -1,7 +1,7 @@
 import { DaimoLinkInvite, DaimoLinkNoteV2, assertNotNull } from "@daimo/common";
 import { DaimoChain } from "@daimo/contract";
 import Octicons from "@expo/vector-icons/Octicons";
-import { addEventListener, getInitialURL } from "expo-linking";
+import { addEventListener } from "expo-linking";
 import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 
@@ -14,6 +14,7 @@ import { UseExistingPage } from "./UseExistingPage";
 import { ActStatus } from "../../../action/actStatus";
 import { useCreateAccount } from "../../../action/useCreateAccount";
 import { useExistingAccount } from "../../../action/useExistingAccount";
+import { getInitialURLOrTag } from "../../../logic/deeplink";
 import { getInvitePasteLink } from "../../../logic/invite";
 import { requestEnclaveSignature } from "../../../logic/key";
 import { NamedError } from "../../../logic/log";
@@ -74,7 +75,7 @@ export default function OnboardingScreen({
 
   // During onboarding, listen for payment or invite link invites
   useEffect(() => {
-    getInitialURL().then((url) => {
+    getInitialURLOrTag().then((url) => {
       if (url == null) return;
       processLink(url);
     });

--- a/apps/daimo-web/public/.well-known/apple-app-site-association
+++ b/apps/daimo-web/public/.well-known/apple-app-site-association
@@ -11,6 +11,10 @@
           {
             "/": "/link/*",
             "comment": "Matches all /link URLs"
+          },
+          {
+            "/": "/l/*",
+            "comment": "Matches all /l URLs"
           }
         ]
       }

--- a/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
@@ -1,4 +1,3 @@
-// SOON TO BE DEPRECATED FOR SHORTER LINKS /l/
 import {
   DaimoAccountStatus,
   DaimoLinkStatus,

--- a/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
@@ -5,7 +5,7 @@ import {
   DaimoRequestStatus,
   assert,
   daimoDomain,
-  daimoLinkBase,
+  daimoLinkBaseV2,
   getAccountName,
   parseDaimoLink,
 } from "@daimo/common";
@@ -36,7 +36,7 @@ const defaultMeta = metadata("Daimo", "Payments on Ethereum");
 
 function getUrl(props: LinkProps): string {
   const path = (props.params.slug || []).join("/");
-  return `${daimoLinkBase}/${path}`;
+  return `${daimoLinkBaseV2}/${path}`;
 }
 
 export async function generateMetadata(props: LinkProps): Promise<Metadata> {

--- a/apps/daimo-web/src/components/AppOrWalletCTA.tsx
+++ b/apps/daimo-web/src/components/AppOrWalletCTA.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import {
   DaimoLinkStatus,
   DaimoNoteStatus,
@@ -23,11 +24,8 @@ import {
   usePrepareContractWrite,
 } from "wagmi";
 
-import {
-  PrimaryOpenInAppButton,
-  SecondaryButton,
-} from "../../../components/buttons";
-import { chainConfig } from "../../../env";
+import { PrimaryOpenInAppButton, SecondaryButton } from "./buttons";
+import { chainConfig } from "../env";
 
 export function AppOrWalletCTA({
   linkStatus,

--- a/apps/daimo-web/src/components/CallToAction.tsx
+++ b/apps/daimo-web/src/components/CallToAction.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  DaimoLinkStatus,
-  daimoLinkBase,
-  daimoLinkBaseFuture,
-} from "@daimo/common";
+import { DaimoLinkStatus, daimoLinkBase, daimoLinkBaseV2 } from "@daimo/common";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
@@ -28,9 +24,7 @@ export function CallToAction({
     // for ephemeral notes.
     const { href } = window.location;
     setDirectDeepLink(
-      href
-        .replace(daimoLinkBase, "daimo:/")
-        .replace(daimoLinkBaseFuture, "daimo:/")
+      href.replace(daimoLinkBase, "daimo:/").replace(daimoLinkBaseV2, "daimo:/")
     );
   }, [directDeepLink]);
 

--- a/apps/daimo-web/src/components/CallToAction.tsx
+++ b/apps/daimo-web/src/components/CallToAction.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { DaimoLinkStatus, daimoLinkBase } from "@daimo/common";
+import {
+  DaimoLinkStatus,
+  daimoLinkBase,
+  daimoLinkBaseFuture,
+} from "@daimo/common";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
 import { AppOrWalletCTA } from "./AppOrWalletCTA";
-import { PrimaryOpenInAppButton } from "../../../components/buttons";
+import { PrimaryOpenInAppButton } from "./buttons";
 
 export function CallToAction({
   description,
@@ -23,7 +27,11 @@ export function CallToAction({
     // Must be loaded client-side to capture the hash part of the URL
     // for ephemeral notes.
     const { href } = window.location;
-    setDirectDeepLink(href.replace(daimoLinkBase, "daimo:/"));
+    setDirectDeepLink(
+      href
+        .replace(daimoLinkBase, "daimo:/")
+        .replace(daimoLinkBaseFuture, "daimo:/")
+    );
   }, [directDeepLink]);
 
   const isInvitePaymentLink = walletActionLinkStatus?.link.type === "notev2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "react-native-gesture-handler": "~2.12.0",
         "react-native-get-random-values": "~1.9.0",
         "react-native-mmkv": "^2.8.0",
+        "react-native-nfc-manager": "^3.14.12",
         "react-native-pager-view": "^6.2.2",
         "react-native-qrcode-svg": "^6.2.0",
         "react-native-reanimated": "~3.3.0",
@@ -23922,6 +23923,14 @@
       "peerDependencies": {
         "react": "*",
         "react-native": ">=0.71.0"
+      }
+    },
+    "node_modules/react-native-nfc-manager": {
+      "version": "3.14.12",
+      "resolved": "https://registry.npmjs.org/react-native-nfc-manager/-/react-native-nfc-manager-3.14.12.tgz",
+      "integrity": "sha512-UtzUGyiwjS5rt76A8Kl22vXjdXJjEBModOUMQ5W53vVKkVcnnIAPS+POWj+HLJPxn4gb5t1FibjLaQnZYdpofw==",
+      "dependencies": {
+        "@expo/config-plugins": "~7.2.5"
       }
     },
     "node_modules/react-native-pager-view": {

--- a/packages/daimo-api/src/api/getLinkStatus.ts
+++ b/packages/daimo-api/src/api/getLinkStatus.ts
@@ -7,6 +7,8 @@ import {
   parseDaimoLink,
   DaimoNoteState,
   DaimoInviteStatus,
+  DaimoLinkRequest,
+  assert,
 } from "@daimo/common";
 import { daimoEphemeralNotesV2Address } from "@daimo/contract";
 import { DaimoNonceMetadata, DaimoNonceType } from "@daimo/userop";
@@ -123,6 +125,35 @@ export async function getLinkStatus(
         isValid,
       };
       return ret;
+    }
+
+    case "tag": {
+      // Tag links serve as simple redirects to other links on the API level.
+      // Currently, they get redirected to returning a request status.
+      const id = link.id;
+      if (id === "rwe") {
+        const randomRequestId = `${BigInt(
+          Math.floor(Math.random() * 1e12)
+        )}` as `${bigint}`;
+        const acc = await nameReg.getEAccountFromStr("daimo");
+        assert(acc != null && acc.name != null);
+
+        const requestLink: DaimoLinkRequest = {
+          type: "request",
+          recipient: acc.name,
+          dollars: "1",
+          requestId: randomRequestId,
+        };
+
+        const ret: DaimoRequestStatus = {
+          link: requestLink,
+          recipient: acc,
+          requestId: randomRequestId,
+        };
+        return ret;
+      } else {
+        throw new Error(`Unknown tag id: ${id}`);
+      }
     }
 
     default:

--- a/packages/daimo-common/src/daimoLink.ts
+++ b/packages/daimo-common/src/daimoLink.ts
@@ -6,7 +6,7 @@ import { BigIntStr, DollarStr, zDollarStr, zHex } from "./model";
 export const daimoDomain =
   process.env.NEXT_PUBLIC_DOMAIN || process.env.DAIMO_DOMAIN;
 
-export const daimoLinkBaseFuture = daimoDomain
+export const daimoLinkBaseV2 = daimoDomain
   ? `https://${daimoDomain}/l`
   : "http://localhost:3001/l";
 
@@ -154,7 +154,7 @@ function parseDaimoLinkInner(link: string): DaimoLink | null {
   let suffix: string | undefined;
   const prefixes = [
     `${daimoLinkBase}/`,
-    `${daimoLinkBaseFuture}/`, // New shorter link prefix
+    `${daimoLinkBaseV2}/`, // New shorter link prefix
     "daimo://",
     "https://daimo.xyz/link/", // Backcompat with old domain
   ];

--- a/packages/daimo-common/src/daimoLink.ts
+++ b/packages/daimo-common/src/daimoLink.ts
@@ -6,6 +6,10 @@ import { BigIntStr, DollarStr, zDollarStr, zHex } from "./model";
 export const daimoDomain =
   process.env.NEXT_PUBLIC_DOMAIN || process.env.DAIMO_DOMAIN;
 
+export const daimoLinkBaseFuture = daimoDomain
+  ? `https://${daimoDomain}/l`
+  : "http://localhost:3001/l";
+
 export const daimoLinkBase = daimoDomain
   ? `https://${daimoDomain}/link`
   : "http://localhost:3001/link";
@@ -17,7 +21,8 @@ export type DaimoLink =
   | DaimoLinkNote
   | DaimoLinkNoteV2
   | DaimoLinkSettings
-  | DaimoLinkInvite;
+  | DaimoLinkInvite
+  | DaimoLinkTag;
 
 /** Represents any Ethereum address */
 export type DaimoLinkAccount = {
@@ -65,6 +70,11 @@ export type DaimoLinkSettings = {
 export type DaimoLinkInvite = {
   type: "invite";
   code: string;
+};
+
+export type DaimoLinkTag = {
+  type: "tag";
+  id: string;
 };
 
 // Returns a shareable https://daimo.com/... deep link.
@@ -118,6 +128,9 @@ function formatDaimoLinkInner(link: DaimoLink, linkBase: string): string {
     case "invite": {
       return `${linkBase}/invite/${link.code}`;
     }
+    case "tag": {
+      return `${linkBase}/t/${link.id}`;
+    }
   }
 }
 
@@ -139,7 +152,12 @@ export function parseDaimoLink(link: string): DaimoLink | null {
 
 function parseDaimoLinkInner(link: string): DaimoLink | null {
   let suffix: string | undefined;
-  const prefixes = [`${daimoLinkBase}/`, "daimo://", "https://daimo.xyz/link/"];
+  const prefixes = [
+    `${daimoLinkBase}/`,
+    `${daimoLinkBaseFuture}/`, // New shorter link prefix
+    "daimo://",
+    "https://daimo.xyz/link/", // Backcompat with old domain
+  ];
   for (const prefix of prefixes) {
     if (link.startsWith(prefix)) {
       suffix = link.substring(prefix.length);
@@ -222,6 +240,11 @@ function parseDaimoLinkInner(link: string): DaimoLink | null {
       if (parts.length !== 2) return null;
       const code = parts[1];
       return { type: "invite", code };
+    }
+    case "t": {
+      if (parts.length !== 2) return null;
+      const id = parts[1];
+      return { type: "tag", id };
     }
     default:
       return null;


### PR DESCRIPTION
for #614 

- shorter link prefix `/l/` instead of `/link/`
- new `tag` type link that just redirects to a `request` in app and behaves as a request link in the API.
- android NDEF_DISCOVERED intent for smooth experience, handle tag launch events on startup as well.

TODO:
- [x] test new shorter prefix deeplinking by deploying the new AASA/assetlinks to prod and double check NFC discovery flow with a release build since Expo Go doesn't make it easy to test that.