### PR TITLE
web: revert payment links look like invites

### DIFF
--- a/apps/daimo-web/src/app/link/[[...slug]]/AppOrWalletCTA.tsx
+++ b/apps/daimo-web/src/app/link/[[...slug]]/AppOrWalletCTA.tsx
@@ -32,10 +32,8 @@ import { chainConfig } from "../../../env";
 export function AppOrWalletCTA({
   linkStatus,
   description,
-  directDeepLink,
 }: {
   linkStatus: DaimoLinkStatus;
-  directDeepLink?: string;
   description: string;
 }) {
   const { address, isConnected } = useAccount();
@@ -81,14 +79,9 @@ export function AppOrWalletCTA({
   const secondaryTitle = descriptionVerb + " WITH CONNECTED WALLET";
   const secondaryConnectTitle = descriptionVerb + " WITH ANOTHER WALLET";
 
-  const isInvitePaymentLink = linkStatus.link.type === "notev2";
-
   return (
     <center>
-      <PrimaryOpenInAppButton
-        disabled={isLoading || isSuccess}
-        inviteDeepLink={isInvitePaymentLink ? directDeepLink : undefined}
-      />
+      <PrimaryOpenInAppButton disabled={isLoading || isSuccess} />
       <div className="h-4" />
       {isConnected && humanReadableError === undefined && (
         <>

--- a/apps/daimo-web/src/app/link/[[...slug]]/CallToAction.tsx
+++ b/apps/daimo-web/src/app/link/[[...slug]]/CallToAction.tsx
@@ -26,15 +26,12 @@ export function CallToAction({
     setDirectDeepLink(href.replace(daimoLinkBase, "daimo:/"));
   }, [directDeepLink]);
 
-  const isInvitePaymentLink = walletActionLinkStatus?.link.type === "notev2";
-
   return (
     <>
       {walletActionLinkStatus ? (
         <AppOrWalletCTA
           linkStatus={walletActionLinkStatus}
           description={description}
-          directDeepLink={directDeepLink}
         />
       ) : (
         <>
@@ -48,8 +45,7 @@ export function CallToAction({
           href={directDeepLink}
           className="block text-center text-primaryLight tracking-wider font-bold py-5"
         >
-          ALREADY HAVE IT? OPEN {isInvitePaymentLink ? "INVITE" : "LINK"} IN
-          DAIMO
+          ALREADY HAVE IT? OPEN IN DAIMO
         </a>
       )}
     </>

--- a/apps/daimo-web/src/components/buttons.tsx
+++ b/apps/daimo-web/src/components/buttons.tsx
@@ -1,45 +1,22 @@
 "use client";
 
-import { useState } from "react";
-
 import { detectPlatform, downloadMetadata } from "../utils/platform";
 
-export function PrimaryOpenInAppButton({
-  inviteDeepLink,
-  disabled,
-}: {
-  inviteDeepLink?: string;
-  disabled?: boolean;
-}) {
-  const [justCopied, setJustCopied] = useState(false);
-
-  const onClick = async () => {
+export function PrimaryOpenInAppButton({ disabled }: { disabled?: boolean }) {
+  const onClick = () => {
     const platform = detectPlatform(navigator.userAgent);
     const { url } = downloadMetadata[platform];
-
-    if (inviteDeepLink) {
-      await navigator.clipboard.writeText(inviteDeepLink);
-      setJustCopied(true);
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      setTimeout(() => setJustCopied(false), 2000);
-    }
-
     console.log("Redirecting to store: " + url);
     window.open(url, "_blank");
   };
 
   return (
     <button
-      className={
-        (justCopied ? "bg-success" : "bg-primaryLight") +
-        " tracking-wider text-white font-bold py-5 w-full rounded-md disabled:opacity-50"
-      }
+      className="bg-primaryLight tracking-wider text-white font-bold py-5 w-full rounded-md disabled:opacity-50"
       disabled={disabled}
       onClick={onClick}
     >
-      {justCopied
-        ? "COPIED, REDIRECTING..."
-        : (inviteDeepLink ? "COPY INVITE AND " : "") + "GET DAIMO"}
+      GET DAIMO
     </button>
   );
 }


### PR DESCRIPTION
the app doesn't have payment link invites enabled yet so anyone landing on this page will be confused

just ran `git checkout 13796c2 apps/daimo-web/`, can revert when we release.