### PR TITLE
Add maximum font size to handle XL font on iOS

### DIFF
--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -103,6 +103,7 @@ function getTabOptions(
     tabBarIconStyle: {
       alignItems: "center",
     },
+    tabBarAllowFontScaling: false,
   };
   switch (route.name) {
     case "DepositTab":

--- a/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
@@ -24,7 +24,12 @@ import { SegmentSlider } from "../../shared/SegmentSlider";
 import Spacer from "../../shared/Spacer";
 import { useNav } from "../../shared/nav";
 import { color, ss, touchHighlightUnderlay } from "../../shared/style";
-import { TextBold, TextLight, TextPara } from "../../shared/text";
+import {
+  MAX_FONT_SIZE_MULTIPLIER,
+  TextBold,
+  TextLight,
+  TextPara,
+} from "../../shared/text";
 import { useWithAccount } from "../../shared/withAccount";
 
 type Tab = "DEPOSIT" | "WITHDRAW";
@@ -167,7 +172,11 @@ function AddressCopier({
         {...touchHighlightUnderlay.subtle}
       >
         <View style={styles.addressView}>
-          <Text style={[styles.addressMono, { color: col }]} numberOfLines={1}>
+          <Text
+            style={[styles.addressMono, { color: col }]}
+            numberOfLines={1}
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          >
             {addr}
           </Text>
           <Octicons name="copy" size={16} color={col} />

--- a/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/receive/DepositScreen.tsx
@@ -7,7 +7,6 @@ import {
   Linking,
   ScrollView,
   StyleSheet,
-  Text,
   TouchableHighlight,
   View,
 } from "react-native";
@@ -24,12 +23,7 @@ import { SegmentSlider } from "../../shared/SegmentSlider";
 import Spacer from "../../shared/Spacer";
 import { useNav } from "../../shared/nav";
 import { color, ss, touchHighlightUnderlay } from "../../shared/style";
-import {
-  MAX_FONT_SIZE_MULTIPLIER,
-  TextBold,
-  TextLight,
-  TextPara,
-} from "../../shared/text";
+import { DaimoText, TextBold, TextLight, TextPara } from "../../shared/text";
 import { useWithAccount } from "../../shared/withAccount";
 
 type Tab = "DEPOSIT" | "WITHDRAW";
@@ -172,13 +166,12 @@ function AddressCopier({
         {...touchHighlightUnderlay.subtle}
       >
         <View style={styles.addressView}>
-          <Text
+          <DaimoText
             style={[styles.addressMono, { color: col }]}
             numberOfLines={1}
-            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           >
             {addr}
-          </Text>
+          </DaimoText>
           <Octicons name="copy" size={16} color={col} />
         </View>
       </TouchableHighlight>

--- a/apps/daimo-mobile/src/view/shared/Amount.tsx
+++ b/apps/daimo-mobile/src/view/shared/Amount.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text } from "react-native";
 
 import Spacer from "./Spacer";
 import { color } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 
 /** 1.23 or 1,23 depending on user locale */
 export const amountSeparator = getLocales()[0].decimalSeparator || ".";
@@ -49,7 +50,7 @@ export function TitleAmount({ amount }: { amount: bigint }) {
   const [dollars, cents] = amountToDollars(amount).split(".");
 
   return (
-    <Text style={styles.title}>
+    <Text style={styles.title} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
       <Text style={styles.titleSmall}>{symbol}</Text>
       <Spacer w={4} />
       {dollars}

--- a/apps/daimo-mobile/src/view/shared/Amount.tsx
+++ b/apps/daimo-mobile/src/view/shared/Amount.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text } from "react-native";
 
 import Spacer from "./Spacer";
 import { color } from "./style";
-import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
+import { DaimoText } from "./text";
 
 /** 1.23 or 1,23 depending on user locale */
 export const amountSeparator = getLocales()[0].decimalSeparator || ".";
@@ -50,13 +50,13 @@ export function TitleAmount({ amount }: { amount: bigint }) {
   const [dollars, cents] = amountToDollars(amount).split(".");
 
   return (
-    <Text style={styles.title} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+    <DaimoText style={styles.title}>
       <Text style={styles.titleSmall}>{symbol}</Text>
       <Spacer w={4} />
       {dollars}
       {amountSeparator}
       {cents}
-    </Text>
+    </DaimoText>
   );
 }
 

--- a/apps/daimo-mobile/src/view/shared/AmountInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AmountInput.tsx
@@ -15,7 +15,7 @@ import { amountSeparator, getAmountText } from "./Amount";
 import Spacer from "./Spacer";
 import { useNav } from "./nav";
 import { color, ss } from "./style";
-import { TextCenter, TextLight } from "./text";
+import { MAX_FONT_SIZE_MULTIPLIER, TextCenter, TextLight } from "./text";
 import { useAccount } from "../../model/account";
 
 // Input components allows entry in range $0.01 to $99,999.99
@@ -165,7 +165,12 @@ function AmountInput({
   return (
     <TouchableWithoutFeedback onPress={focus}>
       <View style={styles.amountInputWrap}>
-        <Text style={styles.amountDollar}>$</Text>
+        <Text
+          style={styles.amountDollar}
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+        >
+          $
+        </Text>
         <TextInput
           ref={ref}
           style={styles.amountInput}

--- a/apps/daimo-mobile/src/view/shared/AmountInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AmountInput.tsx
@@ -178,6 +178,7 @@ function AmountInput({
           placeholder="0"
           placeholderTextColor={color.grayMid}
           numberOfLines={1}
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           focusable={!disabled}
           editable={!disabled}
           selectTextOnFocus

--- a/apps/daimo-mobile/src/view/shared/AmountInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AmountInput.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   NativeSyntheticEvent,
   StyleSheet,
-  Text,
   TextInput,
   TextInputEndEditingEventData,
   TouchableWithoutFeedback,
@@ -15,7 +14,12 @@ import { amountSeparator, getAmountText } from "./Amount";
 import Spacer from "./Spacer";
 import { useNav } from "./nav";
 import { color, ss } from "./style";
-import { MAX_FONT_SIZE_MULTIPLIER, TextCenter, TextLight } from "./text";
+import {
+  DaimoText,
+  MAX_FONT_SIZE_MULTIPLIER,
+  TextCenter,
+  TextLight,
+} from "./text";
 import { useAccount } from "../../model/account";
 
 // Input components allows entry in range $0.01 to $99,999.99
@@ -165,12 +169,7 @@ function AmountInput({
   return (
     <TouchableWithoutFeedback onPress={focus}>
       <View style={styles.amountInputWrap}>
-        <Text
-          style={styles.amountDollar}
-          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-        >
-          $
-        </Text>
+        <DaimoText style={styles.amountDollar}>$</DaimoText>
         <TextInput
           ref={ref}
           style={styles.amountInput}

--- a/apps/daimo-mobile/src/view/shared/AnimatedSearchInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AnimatedSearchInput.tsx
@@ -18,6 +18,7 @@ import Animated, {
 
 import { OctName } from "./InputBig";
 import { color, ss } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const animationConfig = { duration: 150 };
@@ -111,6 +112,7 @@ export function AnimatedSearchInput({
             style={center ? styles.inputCentered : styles.input}
             multiline={Platform.OS === "android" && center}
             numberOfLines={1}
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             autoCapitalize="none"
             autoCorrect={false}
             autoFocus={autoFocus}

--- a/apps/daimo-mobile/src/view/shared/Badge.tsx
+++ b/apps/daimo-mobile/src/view/shared/Badge.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
-import { View, Text } from "react-native";
+import { View } from "react-native";
 
 import { color, ss } from "./style";
-import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
+import { DaimoText } from "./text";
 
 const defaultColor = color.grayMid;
 const defaultBgColor = color.grayLight;
@@ -40,9 +40,7 @@ export function Badge({
 
   return (
     <View style={styleWrap}>
-      <Text style={styleText} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
-        {children}
-      </Text>
+      <DaimoText style={styleText}>{children}</DaimoText>
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/shared/Badge.tsx
+++ b/apps/daimo-mobile/src/view/shared/Badge.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { View, Text } from "react-native";
 
 import { color, ss } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 
 const defaultColor = color.grayMid;
 const defaultBgColor = color.grayLight;
@@ -39,7 +40,9 @@ export function Badge({
 
   return (
     <View style={styleWrap}>
-      <Text style={styleText}>{children}</Text>
+      <Text style={styleText} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+        {children}
+      </Text>
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/shared/Button.tsx
+++ b/apps/daimo-mobile/src/view/shared/Button.tsx
@@ -18,6 +18,7 @@ import Animated, {
 
 import { AnimatedCircle } from "./AnimatedCircle";
 import { color, touchHighlightUnderlay } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 import FaceIdIcon from "../../../assets/face-id.png";
 
 interface TextButtonProps {
@@ -101,7 +102,12 @@ export function LongPressBigButton(props: LongPressButtonProps) {
             size={12}
           />
         </View>
-        <Text style={style.title}>{props.title?.toUpperCase()}</Text>
+        <Text
+          style={style.title}
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+        >
+          {props.title?.toUpperCase()}
+        </Text>
         {props.showBiometricIcon && (
           <View style={styles.biometricIconContainer}>
             <Image source={FaceIdIcon} style={styles.biometricIcon} />
@@ -208,7 +214,12 @@ function Button(
   );
 
   const child = props.title ? (
-    <Text style={props.style.title}>{props.title.toUpperCase()}</Text>
+    <Text
+      style={props.style.title}
+      maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+    >
+      {props.title.toUpperCase()}
+    </Text>
   ) : (
     props.children
   );

--- a/apps/daimo-mobile/src/view/shared/Button.tsx
+++ b/apps/daimo-mobile/src/view/shared/Button.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import {
   Image,
   StyleSheet,
-  Text,
   TextStyle,
   TouchableHighlight,
   View,
@@ -18,7 +17,7 @@ import Animated, {
 
 import { AnimatedCircle } from "./AnimatedCircle";
 import { color, touchHighlightUnderlay } from "./style";
-import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
+import { DaimoText } from "./text";
 import FaceIdIcon from "../../../assets/face-id.png";
 
 interface TextButtonProps {
@@ -102,12 +101,7 @@ export function LongPressBigButton(props: LongPressButtonProps) {
             size={12}
           />
         </View>
-        <Text
-          style={style.title}
-          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-        >
-          {props.title?.toUpperCase()}
-        </Text>
+        <DaimoText style={style.title}>{props.title?.toUpperCase()}</DaimoText>
         {props.showBiometricIcon && (
           <View style={styles.biometricIconContainer}>
             <Image source={FaceIdIcon} style={styles.biometricIcon} />
@@ -214,12 +208,7 @@ function Button(
   );
 
   const child = props.title ? (
-    <Text
-      style={props.style.title}
-      maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-    >
-      {props.title.toUpperCase()}
-    </Text>
+    <DaimoText style={props.style.title}>{props.title.toUpperCase()}</DaimoText>
   ) : (
     props.children
   );

--- a/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
+++ b/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
@@ -105,7 +105,7 @@ export function Bubble({
 
   return (
     <View style={style}>
-      <Text style={textStyle} numberOfLines={1}>
+      <Text style={textStyle} numberOfLines={1} allowFontScaling={false}>
         {children}
       </Text>
     </View>

--- a/apps/daimo-mobile/src/view/shared/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/shared/HistoryList.tsx
@@ -25,7 +25,12 @@ import { PendingDot } from "./PendingDot";
 import Spacer from "./Spacer";
 import { useNav } from "./nav";
 import { color, ss, touchHighlightUnderlay } from "./style";
-import { TextBody, TextCenter, TextLight } from "./text";
+import {
+  MAX_FONT_SIZE_MULTIPLIER,
+  TextBody,
+  TextCenter,
+  TextLight,
+} from "./text";
 import { getCachedEAccount } from "../../logic/addr";
 import { Account } from "../../model/account";
 
@@ -155,7 +160,12 @@ export function HistoryListSwipe({
 function HeaderRow({ title }: { title: string }) {
   return (
     <View style={styles.rowHeader}>
-      <Text style={[ss.text.body, { color: color.gray3 }]}>{title}</Text>
+      <Text
+        style={[ss.text.body, { color: color.gray3 }]}
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+      >
+        {title}
+      </Text>
     </View>
   );
 }
@@ -272,10 +282,18 @@ function TransferAmountDate({
 
   return (
     <View style={styles.transferAmountDate}>
-      <Text style={[ss.text.metadata, { color: amountCol }]}>
+      <Text
+        style={[ss.text.metadata, { color: amountCol }]}
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+      >
         {sign} {dollarStr}
       </Text>
-      <Text style={[ss.text.metadataLight, { color: textCol }]}>{timeStr}</Text>
+      <Text
+        style={[ss.text.metadataLight, { color: textCol }]}
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+      >
+        {timeStr}
+      </Text>
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/shared/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/shared/HistoryList.tsx
@@ -9,13 +9,7 @@ import {
 } from "@daimo/common";
 import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
 import { useCallback } from "react";
-import {
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableHighlight,
-  View,
-} from "react-native";
+import { Platform, StyleSheet, TouchableHighlight, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Address } from "viem";
 
@@ -25,12 +19,7 @@ import { PendingDot } from "./PendingDot";
 import Spacer from "./Spacer";
 import { useNav } from "./nav";
 import { color, ss, touchHighlightUnderlay } from "./style";
-import {
-  MAX_FONT_SIZE_MULTIPLIER,
-  TextBody,
-  TextCenter,
-  TextLight,
-} from "./text";
+import { DaimoText, TextBody, TextCenter, TextLight } from "./text";
 import { getCachedEAccount } from "../../logic/addr";
 import { Account } from "../../model/account";
 
@@ -160,12 +149,9 @@ export function HistoryListSwipe({
 function HeaderRow({ title }: { title: string }) {
   return (
     <View style={styles.rowHeader}>
-      <Text
-        style={[ss.text.body, { color: color.gray3 }]}
-        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-      >
+      <DaimoText style={[ss.text.body, { color: color.gray3 }]}>
         {title}
-      </Text>
+      </DaimoText>
     </View>
   );
 }
@@ -282,18 +268,12 @@ function TransferAmountDate({
 
   return (
     <View style={styles.transferAmountDate}>
-      <Text
-        style={[ss.text.metadata, { color: amountCol }]}
-        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-      >
+      <DaimoText style={[ss.text.metadata, { color: amountCol }]}>
         {sign} {dollarStr}
-      </Text>
-      <Text
-        style={[ss.text.metadataLight, { color: textCol }]}
-        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-      >
+      </DaimoText>
+      <DaimoText style={[ss.text.metadataLight, { color: textCol }]}>
         {timeStr}
-      </Text>
+      </DaimoText>
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/shared/InputBig.tsx
+++ b/apps/daimo-mobile/src/view/shared/InputBig.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 
 import { color, ss } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 
 export type OctName = typeof Octicons extends Icon<infer G, any> ? G : never;
 
@@ -70,6 +71,7 @@ export function InputBig({
           style={center ? styles.inputCentered : styles.input}
           multiline={Platform.OS === "android" && center}
           numberOfLines={1}
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           autoCapitalize="none"
           autoCorrect={false}
           spellCheck={false}

--- a/apps/daimo-mobile/src/view/shared/IntroTextParagraph.tsx
+++ b/apps/daimo-mobile/src/view/shared/IntroTextParagraph.tsx
@@ -2,10 +2,15 @@ import { ReactNode, useRef } from "react";
 import { StyleSheet, Text } from "react-native";
 
 import { color, ss } from "./style";
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
 
 export function IntroTextParagraph({ children }: { children: ReactNode }) {
   const style = useRef([styles.introText, { color: color.grayDark }]).current;
-  return <Text style={style}>{children}</Text>;
+  return (
+    <Text style={style} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+      {children}
+    </Text>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/daimo-mobile/src/view/shared/IntroTextParagraph.tsx
+++ b/apps/daimo-mobile/src/view/shared/IntroTextParagraph.tsx
@@ -1,16 +1,12 @@
 import { ReactNode, useRef } from "react";
-import { StyleSheet, Text } from "react-native";
+import { StyleSheet } from "react-native";
 
 import { color, ss } from "./style";
-import { MAX_FONT_SIZE_MULTIPLIER } from "./text";
+import { DaimoText } from "./text";
 
 export function IntroTextParagraph({ children }: { children: ReactNode }) {
   const style = useRef([styles.introText, { color: color.grayDark }]).current;
-  return (
-    <Text style={style} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
-      {children}
-    </Text>
-  );
+  return <DaimoText style={style}>{children}</DaimoText>;
 }
 
 const styles = StyleSheet.create({

--- a/apps/daimo-mobile/src/view/shared/text.tsx
+++ b/apps/daimo-mobile/src/view/shared/text.tsx
@@ -4,7 +4,7 @@ import { Text, TextProps, TextStyle } from "react-native";
 
 import { color, ss } from "./style";
 
-export const MAX_FONT_SIZE_MULTIPLIER = 1.3;
+export const MAX_FONT_SIZE_MULTIPLIER = 1.4;
 
 function useStyle(baseStyle: TextStyle, { color }: { color?: string }) {
   return useMemo(() => [baseStyle, { color }], [baseStyle, color]);

--- a/apps/daimo-mobile/src/view/shared/text.tsx
+++ b/apps/daimo-mobile/src/view/shared/text.tsx
@@ -10,36 +10,36 @@ function useStyle(baseStyle: TextStyle, { color }: { color?: string }) {
   return useMemo(() => [baseStyle, { color }], [baseStyle, color]);
 }
 
-const TextWrapped = (props: TextProps) => {
+export const DaimoText = (props: TextProps) => {
   return <Text {...props} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} />;
 };
 
 export function TextH1(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.h1, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.h1, props)} />;
 }
 
 export function TextH2(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.h2, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.h2, props)} />;
 }
 
 export function TextH3(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.h3, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.h3, props)} />;
 }
 
 export function TextBody(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.body, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.body, props)} />;
 }
 
 export function TextBodyCaps(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.bodyCaps, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.bodyCaps, props)} />;
 }
 
 export function TextMeta(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.metadata, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.metadata, props)} />;
 }
 
 export function TextPara(props: TextProps & { color?: string }) {
-  return <TextWrapped {...props} style={useStyle(ss.text.para, props)} />;
+  return <DaimoText {...props} style={useStyle(ss.text.para, props)} />;
 }
 
 export function TextLight(props: TextProps) {
@@ -47,15 +47,15 @@ export function TextLight(props: TextProps) {
 }
 
 export function TextBold(props: TextProps) {
-  return <TextWrapped {...props} style={ss.text.bold} />;
+  return <DaimoText {...props} style={ss.text.bold} />;
 }
 
 export function TextCenter(props: TextProps) {
-  return <TextWrapped {...props} style={ss.text.center} />;
+  return <DaimoText {...props} style={ss.text.center} />;
 }
 
 export function TextError(props: TextProps) {
-  return <TextWrapped {...props} style={ss.text.error} />;
+  return <DaimoText {...props} style={ss.text.error} />;
 }
 
 type OcticonName = React.ComponentProps<typeof Octicons>["name"];

--- a/apps/daimo-mobile/src/view/shared/text.tsx
+++ b/apps/daimo-mobile/src/view/shared/text.tsx
@@ -4,36 +4,42 @@ import { Text, TextProps, TextStyle } from "react-native";
 
 import { color, ss } from "./style";
 
+export const MAX_FONT_SIZE_MULTIPLIER = 1.3;
+
 function useStyle(baseStyle: TextStyle, { color }: { color?: string }) {
   return useMemo(() => [baseStyle, { color }], [baseStyle, color]);
 }
 
+const TextWrapped = (props: TextProps) => {
+  return <Text {...props} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} />;
+};
+
 export function TextH1(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.h1, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.h1, props)} />;
 }
 
 export function TextH2(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.h2, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.h2, props)} />;
 }
 
 export function TextH3(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.h3, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.h3, props)} />;
 }
 
 export function TextBody(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.body, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.body, props)} />;
 }
 
 export function TextBodyCaps(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.bodyCaps, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.bodyCaps, props)} />;
 }
 
 export function TextMeta(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.metadata, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.metadata, props)} />;
 }
 
 export function TextPara(props: TextProps & { color?: string }) {
-  return <Text {...props} style={useStyle(ss.text.para, props)} />;
+  return <TextWrapped {...props} style={useStyle(ss.text.para, props)} />;
 }
 
 export function TextLight(props: TextProps) {
@@ -41,15 +47,15 @@ export function TextLight(props: TextProps) {
 }
 
 export function TextBold(props: TextProps) {
-  return <Text {...props} style={ss.text.bold} />;
+  return <TextWrapped {...props} style={ss.text.bold} />;
 }
 
 export function TextCenter(props: TextProps) {
-  return <Text {...props} style={ss.text.center} />;
+  return <TextWrapped {...props} style={ss.text.center} />;
 }
 
 export function TextError(props: TextProps) {
-  return <Text {...props} style={ss.text.error} />;
+  return <TextWrapped {...props} style={ss.text.error} />;
 }
 
 type OcticonName = React.ComponentProps<typeof Octicons>["name"];
@@ -67,11 +73,19 @@ export function EmojiToOcticon({ text, size }: { text: string; size: number }) {
   let match, last;
   for (last = 0; (match = regex.exec(text)) != null; last = regex.lastIndex) {
     const joiningPart = text.substring(last, match.index);
-    parts.push(<Text key={last}>{joiningPart}</Text>);
+    parts.push(
+      <Text key={last} allowFontScaling={false}>
+        {joiningPart}
+      </Text>
+    );
     const octiconName = emojiToOcticon[match[0]];
     parts.push(<Octicons key={last + 1} size={size} name={octiconName} />);
   }
-  parts.push(<Text key={last}>{text.substring(last)}</Text>);
+  parts.push(
+    <Text key={last} allowFontScaling={false}>
+      {text.substring(last)}
+    </Text>
+  );
 
   return <>{parts}</>;
 }


### PR DESCRIPTION
Add maximum font size and don't allow font scaling in some places.
Maybe we should consider all <Text> being imported from text.tsx file instead of React Native but in this PR I added necessary prop to all instances without risk of breaking anything

Closes #449

iOS:

https://github.com/daimo-eth/daimo/assets/42337257/043347b1-7848-434b-a162-4806a55c0c4a

Android:

https://github.com/daimo-eth/daimo/assets/42337257/215e0d3a-d11e-4b19-bb4c-cf2c89ace5b6

