### PR TITLE
mobile: fix Play Console deeplinks warning

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -1,7 +1,7 @@
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
 const VERSION = "1.5.0";
-const BUILD_NUM = 101;
+const BUILD_NUM = 102;
 
 export default {
   owner: "daimo",

--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -45,7 +45,7 @@ export default {
       : "./google-services.json",
     intentFilters: [
       {
-        action: "VIEW",
+        action: ["VIEW", "NDEF_DISCOVERED"],
         autoVerify: true,
         data: [
           {
@@ -69,31 +69,7 @@ export default {
         category: ["BROWSABLE", "DEFAULT"],
       },
       {
-        action: "NDEF_DISCOVERED",
-        autoVerify: true,
-        data: [
-          {
-            scheme: "https",
-            host: "daimo.com",
-            pathPrefix: "/link",
-          },
-        ],
-        category: ["BROWSABLE", "DEFAULT"],
-      },
-      {
-        action: "VIEW",
-        autoVerify: true,
-        data: [
-          {
-            scheme: "https",
-            host: "daimo.com",
-            pathPrefix: "/l",
-          },
-        ],
-        category: ["BROWSABLE", "DEFAULT"],
-      },
-      {
-        action: "NDEF_DISCOVERED",
+        action: ["VIEW", "NDEF_DISCOVERED"],
         autoVerify: true,
         data: [
           {


### PR DESCRIPTION
simplify `app.config.js`, consolidate regular deep links and NFC tap deep links