### PR TITLE
onboarding: fix key load or create race

### DIFF
--- a/apps/daimo-mobile/src/view/screen/onboarding/IntroPages.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/IntroPages.tsx
@@ -6,9 +6,9 @@ import {
   View,
   StyleSheet,
 } from "react-native";
-import { Hex } from "viem";
 
 import { ActStatus } from "../../../action/actStatus";
+import { DeviceKeyStatus } from "../../../action/key";
 import { ButtonBig, TextButton } from "../../shared/Button";
 import { InfoLink } from "../../shared/InfoLink";
 import { IntroTextParagraph } from "../../shared/IntroTextParagraph";
@@ -18,12 +18,12 @@ import { TextCenter, TextH1 } from "../../shared/text";
 
 export function IntroPages({
   useExistingStatus,
-  useExistingPubKeyHex,
+  keyStatus,
   existingNext,
   onNext,
 }: {
   useExistingStatus: ActStatus;
-  useExistingPubKeyHex: Hex | undefined;
+  keyStatus: DeviceKeyStatus;
   existingNext: () => void;
   onNext: ({ choice }: { choice: "create" | "existing" }) => void;
 }) {
@@ -35,7 +35,7 @@ export function IntroPages({
   };
 
   useEffect(() => {
-    if (useExistingPubKeyHex && useExistingStatus === "success") existingNext();
+    if (keyStatus.pubKeyHex && useExistingStatus === "success") existingNext();
   }, [useExistingStatus]);
 
   return (

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -12,6 +12,7 @@ import { InvitePage } from "./InvitePage";
 import { OnboardingHeader } from "./OnboardingHeader";
 import { UseExistingPage } from "./UseExistingPage";
 import { ActStatus } from "../../../action/actStatus";
+import { useLoadOrCreateEnclaveKey } from "../../../action/key";
 import { useCreateAccount } from "../../../action/useCreateAccount";
 import { useExistingAccount } from "../../../action/useExistingAccount";
 import { getInitialURLOrTag } from "../../../logic/deeplink";
@@ -87,21 +88,20 @@ export default function OnboardingScreen({
 
   console.log(`[ONBOARDING] chainId ${daimoChain}`);
 
+  const keyStatus = useLoadOrCreateEnclaveKey();
+
   // Create an account as soon as possible, hiding latency
   const {
     exec: createExec,
     reset: createReset,
     status: createStatus,
     message: createMessage,
-  } = useCreateAccount(name, inviteLink, daimoChain);
+  } = useCreateAccount(name, inviteLink, daimoChain, keyStatus);
 
   // Use existing account spin loops and waits for the device key to show up
   // in any on-chain account.
-  const {
-    status: useExistingStatus,
-    message: useExistingMessage,
-    pubKeyHex: useExistingPubKeyHex,
-  } = useExistingAccount(daimoChain);
+  const { status: useExistingStatus, message: useExistingMessage } =
+    useExistingAccount(daimoChain, keyStatus);
 
   const existingNext = getNext(
     "existing",
@@ -123,7 +123,7 @@ export default function OnboardingScreen({
       {page === "intro" && (
         <IntroPages
           useExistingStatus={useExistingStatus}
-          useExistingPubKeyHex={useExistingPubKeyHex}
+          keyStatus={keyStatus}
           existingNext={existingNext}
           onNext={next}
         />
@@ -156,7 +156,7 @@ export default function OnboardingScreen({
         <UseExistingPage
           useExistingStatus={useExistingStatus}
           useExistingMessage={useExistingMessage}
-          useExistingPubKeyHex={useExistingPubKeyHex}
+          keyStatus={keyStatus}
           onNext={next}
           onPrev={prev}
           daimoChain={daimoChain}

--- a/apps/daimo-mobile/src/view/screen/onboarding/UseExistingPage.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/UseExistingPage.tsx
@@ -13,6 +13,7 @@ import { Hex, hexToBytes } from "viem";
 
 import { OnboardingHeader } from "./OnboardingHeader";
 import { ActStatus } from "../../../action/actStatus";
+import { DeviceKeyStatus } from "../../../action/key";
 import { useSendAsync } from "../../../action/useSendAsync";
 import { createEmptyAccount } from "../../../logic/account";
 import { env } from "../../../logic/env";
@@ -35,14 +36,14 @@ import { QRCodeBox } from "../QRScreen";
 export function UseExistingPage({
   useExistingStatus,
   useExistingMessage,
-  useExistingPubKeyHex,
+  keyStatus,
   onNext,
   onPrev,
   daimoChain,
 }: {
   useExistingStatus: ActStatus;
   useExistingMessage: string;
-  useExistingPubKeyHex: Hex | undefined;
+  keyStatus: DeviceKeyStatus;
   onNext: () => void;
   onPrev?: () => void;
   daimoChain: DaimoChain;
@@ -51,14 +52,25 @@ export function UseExistingPage({
     if (useExistingStatus === "success") onNext();
   }, [useExistingStatus]);
 
-  if (useExistingPubKeyHex === undefined) return null;
-
+  if (keyStatus.pubKeyHex === undefined) {
+    return (
+      <View>
+        <OnboardingHeader title="Existing Account" onPrev={onPrev} />
+        <View style={styles.useExistingPage}>
+          <Spacer h={24} />
+          <TextCenter>
+            <TextBody>Generating keys...</TextBody>
+          </TextCenter>
+        </View>
+      </View>
+    );
+  }
   return (
     <View>
       <OnboardingHeader title="Existing Account" onPrev={onPrev} />
       <View style={styles.useExistingPage}>
         <Spacer h={24} />
-        <QRCodeBox value={createAddDeviceString(useExistingPubKeyHex)} />
+        <QRCodeBox value={createAddDeviceString(keyStatus.pubKeyHex)} />
         <Spacer h={16} />
         <TextCenter>
           {useExistingStatus !== "error" && (
@@ -80,7 +92,7 @@ export function UseExistingPage({
         </TextCenter>
         <Spacer h={16} />
         <RestoreFromBackupButton
-          pubKeyHex={useExistingPubKeyHex}
+          pubKeyHex={keyStatus.pubKeyHex}
           daimoChain={daimoChain}
         />
       </View>


### PR DESCRIPTION
unify key load or creation to prevent race condition between createAccount and useExisting.

tested by running through onboarding > delete device a handful of times.