### PR TITLE
mobile: do not double handle initalURL

### DIFF
--- a/apps/daimo-mobile/src/logic/deeplink.ts
+++ b/apps/daimo-mobile/src/logic/deeplink.ts
@@ -2,10 +2,19 @@ import { getInitialURL } from "expo-linking";
 import { Platform } from "react-native";
 import NfcManager, { Ndef, NdefRecord } from "react-native-nfc-manager";
 
+// If an initialURL previously triggered app launch in onboarding state,
+// we don't want to trigger it again.
+let hasHandledInitialInOnboarding = false;
+
 // User opened app via deeplink or scanning an NFC tag: return URL, otherwise null.
-export async function getInitialURLOrTag() {
+export async function getInitialURLOrTag(isOnboarding: boolean) {
+  if (hasHandledInitialInOnboarding && !isOnboarding) return null;
+  if (isOnboarding) hasHandledInitialInOnboarding = true;
+
   const deeplinkURL = await getInitialURL();
-  if (deeplinkURL) return deeplinkURL;
+  if (deeplinkURL) {
+    return deeplinkURL;
+  }
 
   if (Platform.OS === "android") {
     const tag = await NfcManager.getLaunchTagEvent();

--- a/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
@@ -303,7 +303,7 @@ function useInitNavLinks() {
 
     console.log(`[NAV] listening for deep links, account ${account.name}`);
     deepLinkInitialised = true;
-    getInitialURLOrTag().then((url) => {
+    getInitialURLOrTag(false).then((url) => {
       if (url == null) return;
       handleDeepLink(nav, url);
     });

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -75,7 +75,7 @@ export default function OnboardingScreen({
 
   // During onboarding, listen for payment or invite link invites
   useEffect(() => {
-    getInitialURLOrTag().then((url) => {
+    getInitialURLOrTag(true).then((url) => {
       if (url == null) return;
       processLink(url);
     });


### PR DESCRIPTION
https://streamable.com/xxf73e

Fixes #650 : if the app is launched by an initialURL during onboarding, it will double trigger action to it which looks bad after onboarding from payment links