### PR TITLE
api: bump shovel limit

### DIFF
--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -9,9 +9,9 @@ interface indexer {
 
 const dbConfig: ClientConfig = {
   connectionString: process.env.SHOVEL_DATABASE_URL,
-  connectionTimeoutMillis: 5000,
-  query_timeout: 5000,
-  statement_timeout: 5000,
+  connectionTimeoutMillis: 10000,
+  query_timeout: 10000,
+  statement_timeout: 10000,
   database: process.env.SHOVEL_DATABASE_URL == null ? "shovel" : undefined,
 };
 


### PR DESCRIPTION
Couple server fails in the last day with `Query read timeout` https://logs.betterstack.com/team/183561/tail?a=1706558645199434-104000491&rf=now-60m&q=syslog.host%3D%22daimo-api-prod%22

hotfix for now, in future we should add a retry loop