### PR TITLE
Use % instead of numbers to handle resize of Mac app

### DIFF
--- a/apps/daimo-mobile/src/view/shared/useSwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/useSwipeUpDown.tsx
@@ -25,13 +25,6 @@ export function useSwipeUpDown({
 }) {
   const [isBottomSheetOpen, setIsOpen] = useState(false);
 
-  // Dimensions
-  const tabBarHeight = useTabBarHeight();
-  const screenHeight =
-    screenDimensions.height -
-    tabBarHeight -
-    (Platform.OS === "android" ? 16 : 0);
-
   // Hide bottom sheet when tapping a bottom tab.
   const nav = useNav();
   const isFocused = useIsFocused();
@@ -60,11 +53,7 @@ export function useSwipeUpDown({
 
   const bottomSheet = (
     <Animated.View
-      style={[
-        { height: screenHeight },
-        styles.bottomSheetContainer,
-        bottomSheetScrollStyle,
-      ]}
+      style={[styles.bottomSheetContainer, bottomSheetScrollStyle]}
       pointerEvents="box-none"
     >
       <SwipeUpDown
@@ -88,6 +77,7 @@ export function useSwipeUpDown({
 const styles = StyleSheet.create({
   bottomSheetContainer: {
     position: "absolute",
-    width: SCREEN_WIDTH,
+    height: "100%",
+    width: "100%",
   },
 });

--- a/apps/daimo-mobile/src/view/shared/useSwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/useSwipeUpDown.tsx
@@ -1,12 +1,10 @@
-import { SCREEN_WIDTH } from "@gorhom/bottom-sheet";
 import { useIsFocused } from "@react-navigation/native";
 import { ReactNode, useCallback, useEffect, useState } from "react";
-import { Dimensions, Platform, StyleSheet } from "react-native";
+import { Dimensions, StyleSheet } from "react-native";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
 
 import { SwipeUpDown, SwipeUpDownRef } from "./SwipeUpDown";
 import { useNav } from "./nav";
-import useTabBarHeight from "../../common/useTabBarHeight";
 
 const screenDimensions = Dimensions.get("screen");
 


### PR DESCRIPTION
Closes #659

Handle bottom sheet so it works even after resizing on Mac OS (Still looks kinda strange while transition though but it usable)

Mac OS:

https://github.com/daimo-eth/daimo/assets/42337257/a8222bf8-b421-4595-a5e3-a6b043fd830d

After tests android and iOS seems to working same as before change