### PR TITLE
Fix infoBox wrapping on iPad and macOS

### DIFF
--- a/apps/daimo-mobile/src/view/shared/InfoBox.tsx
+++ b/apps/daimo-mobile/src/view/shared/InfoBox.tsx
@@ -49,7 +49,6 @@ const styles = StyleSheet.create({
   },
   bubbleText: {
     flex: 1,
-    flexDirection: "row",
-    flexWrap: "wrap",
+    flexDirection: "column",
   },
 });


### PR DESCRIPTION
Closes #648

iPad:

![Zrzut ekranu 2024-02-1 o 00 52 35](https://github.com/daimo-eth/daimo/assets/42337257/67787345-be6c-43fc-be2d-df5f4e4945a4)

macOS:

![Zrzut ekranu 2024-02-1 o 00 50 27](https://github.com/daimo-eth/daimo/assets/42337257/6b8c3bc3-d42e-46ea-8f12-5e141c52ddc3)

iOS:

![Zrzut ekranu 2024-02-1 o 00 50 20](https://github.com/daimo-eth/daimo/assets/42337257/54cff131-28c0-4e18-99e6-9d78885cf01b)

Android:

![Zrzut ekranu 2024-02-1 o 00 50 16](https://github.com/daimo-eth/daimo/assets/42337257/f9cc4fe1-cf17-4bb7-bea9-fa6f0dcd2b8f)
