### PR TITLE
daimo-api: update shovel watcher to use latest shovel schema

### DIFF
--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -23,6 +23,7 @@ const poolConfig: PoolConfig = {
 
 export class Watcher {
   private latest = chainConfig.chainL2.testnet ? 8750000n : 5700000n;
+  private srcName = chainConfig.chainL2.testnet ? "base-goerli" : "base";
   private batchSize = 100000n;
 
   private indexers: indexer[] = [];
@@ -107,13 +108,8 @@ export class Watcher {
 
   async getShovelLatest(): Promise<bigint> {
     const result = await this.pg.query(
-      `
-      select max(num) as num
-      from shovel.task_updates
-      where chain_id = $1
-      and backfill = false;
-    `,
-      [chainConfig.chainL2.id]
+      `select num from shovel.latest where src_name = $1 `,
+      [this.srcName]
     );
     return BigInt(result.rows[0].num);
   }

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -23,7 +23,6 @@ const poolConfig: PoolConfig = {
 
 export class Watcher {
   private latest = chainConfig.chainL2.testnet ? 8750000n : 5700000n;
-  private srcName = chainConfig.chainL2.testnet ? "base-goerli" : "base";
   private batchSize = 100000n;
 
   private indexers: indexer[] = [];
@@ -107,10 +106,7 @@ export class Watcher {
   }
 
   async getShovelLatest(): Promise<bigint> {
-    const result = await this.pg.query(
-      `select num from shovel.latest where src_name = $1 `,
-      [this.srcName]
-    );
+    const result = await this.pg.query(`select num from shovel.latest`);
     return BigInt(result.rows[0].num);
   }
 }


### PR DESCRIPTION
The latest version of shovel exposed a view that callers can use to see where Shovel is at in the chain.

https://github.com/indexsupply/code/pull/232