### PR TITLE
mobile: simplified bottom-sheet bounce

### DIFF
--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -216,6 +216,7 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
         enableContentPanningGesture={!disabled}
         activeOffsetX={[-SCREEN_WIDTH, SCREEN_WIDTH]}
         activeOffsetY={[-10, 10]}
+        animationConfigs={ANIMATION_CONFIG}
       >
         <ToggleBottomSheetContext.Provider value={toggleBottomSheet}>
           <Animated.View
@@ -238,6 +239,13 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
     );
   }
 );
+
+const ANIMATION_CONFIG = {
+  stiffness: 160,
+  damping: 18,
+  mass: 1,
+  restDisplacement: 1,
+};
 
 const styles = StyleSheet.create({
   itemMiniWrapper: {


### PR DESCRIPTION
## Summary

- Uses the bounce from #688, but without changing the inner content
- (The video in #633 suggested changing the direction the inner content slides too--but added too much engineering complexity.)

## Screenshot

https://github.com/daimo-eth/daimo/assets/169280/8ea046c1-9e3e-45d7-a136-ae406c8c836d

