### PR TITLE
Re-add interpolator but working

### DIFF
--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -11,11 +11,13 @@ import {
   createNativeStackNavigator,
 } from "@react-navigation/native-stack";
 import {
+  StackCardInterpolationProps,
+  StackCardStyleInterpolator,
   TransitionPresets,
   createStackNavigator,
 } from "@react-navigation/stack";
 import { useEffect, useState } from "react";
-import { Platform } from "react-native";
+import { Animated, Platform } from "react-native";
 import { EdgeInsets, useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AccountScreen } from "./screen/AccountScreen";
@@ -46,6 +48,8 @@ import {
 import { color } from "./shared/style";
 import { TAB_BAR_HEIGHT } from "../common/useTabBarHeight";
 import { useAccount } from "../model/account";
+
+const { add, multiply } = Animated;
 
 const Tab = createMaterialTopTabNavigator<ParamListTab>();
 const MainStack = createStackNavigator<ParamListMain>();
@@ -82,6 +86,49 @@ export function TabNav() {
 
   if (!isOnboarded) return <OnboardingScreen {...{ onOnboardingComplete }} />;
 
+  // Error modal slides up from the bottom, greying out the app below.
+  const forModalPresentationIOS: StackCardStyleInterpolator = ({
+    current,
+    next,
+    inverted,
+    layouts: { screen },
+  }: StackCardInterpolationProps) => {
+    const progress = add(
+      current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+        extrapolate: "clamp",
+      }),
+      next
+        ? next.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1],
+            extrapolate: "clamp",
+          })
+        : 0
+    );
+
+    const translateY = multiply(
+      progress.interpolate({
+        inputRange: [0, 1, 2],
+        outputRange: [screen.height, 0, 0],
+      }),
+      inverted
+    );
+
+    const overlayOpacity = progress.interpolate({
+      inputRange: [0, 1, 1.0001, 2],
+      outputRange: [0, 0.3, 1, 1],
+    });
+
+    return {
+      cardStyle: {
+        transform: [{ translateY }],
+      },
+      overlayStyle: { opacity: overlayOpacity },
+    };
+  };
+
   return (
     <MainStack.Navigator initialRouteName="MainTabNav">
       <MainStack.Group>
@@ -107,6 +154,7 @@ export function TabNav() {
             ...TransitionPresets.ModalPresentationIOS,
             detachPreviousScreen: false,
             gestureResponseDistance: WINDOW_HEIGHT,
+            cardStyleInterpolator: forModalPresentationIOS,
           }}
         />
       </MainStack.Group>

--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -87,6 +87,7 @@ export function TabNav() {
   if (!isOnboarded) return <OnboardingScreen {...{ onOnboardingComplete }} />;
 
   // Error modal slides up from the bottom, greying out the app below.
+  // This custom interpolator recreates the native background effect.
   const forModalPresentationIOS: StackCardStyleInterpolator = ({
     current,
     next,


### PR DESCRIPTION
While laying in bed I realized I made a horrible, yet silly mistake: https://github.com/daimo-eth/daimo/pull/699 This PR actually changes modal animation a loooot, but I haven't realized at the time because I created my first draft by modifying the library code and then moving it into our codebase so after removal from our codebase it this PR it worked for me perfectly the same as before. But it shouldn't. 😳

So after reinstalling the stack library without my local changes it looks like this:

https://github.com/daimo-eth/daimo/assets/42337257/a016b427-7f36-4d1e-9681-3b20572d3484

https://github.com/daimo-eth/daimo/assets/42337257/c9d74135-d913-4e05-8ad0-53ca104f72b6

But after actually fixing it it looks like this:

https://github.com/daimo-eth/daimo/assets/42337257/fc67eeb0-c136-402c-9908-21c487d1a8db

https://github.com/daimo-eth/daimo/assets/42337257/937019c5-b60c-470e-9425-9a50822b2565

I kinda like both so feel free to close this PR if you feel like the solution without the custom animation looks or feels better or is just much better because of the cleaner code. 

Sorry for confusion 🙏