### PR TITLE
Modify info.plist to block only 2 window size variants for Mac app

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -32,9 +32,18 @@ export default {
     config: {
       usesNonExemptEncryption: false,
     },
+    requireFullScreen: true,
     infoPlist: {
       LSApplicationQueriesSchemes: ["whatsapp", "sgnl", "tg", "mailto", "sms"],
       NFCReaderUsageDescription: "Daimo uses NFC for tap-to-pay checkout.",
+      UIRequiresFullScreen: true,
+      UISupportsTrueScreenSizeOnMac: false,
+      "UISupportedInterfaceOrientations~ipad": [
+        "UIInterfaceOrientationPortrait",
+        "UIInterfaceOrientationPortraitUpsideDown",
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight",
+      ],
     },
   },
   android: {


### PR DESCRIPTION
Modify info.plist to block only 2 window size variants for Mac app to avoid ugly animations, and strange size variants

Mac:

https://github.com/daimo-eth/daimo/assets/42337257/0034ef1d-cbce-45ab-a119-edea552f7819

