### PR TITLE
update canary build number

### DIFF
--- a/apps/daimo-mobile/app.config.js
+++ b/apps/daimo-mobile/app.config.js
@@ -1,6 +1,6 @@
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.5.4";
+const VERSION = "1.5.5";
 
 export default {
   owner: "daimo",


### PR DESCRIPTION
Master continous deploy is failing because 1.5.4 was released in #719 , public release versions cannot be re-used for canary internal builds: https://github.com/daimo-eth/daimo/actions/runs/7921106455/job/21625654302