### PR TITLE
Make offline header pressable on home screen

### DIFF
--- a/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
+++ b/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
@@ -21,7 +21,7 @@ export function OfflineHeader({
 }) {
   const [refreshing, setRefreshing] = useState(false);
   const netState = useNetworkState();
-  const isOffline = netState.status !== "offline";
+  const isOffline = netState.status === "offline";
 
   const ins = useSafeAreaInsets();
   const top = Math.max(ins.top, 16);

--- a/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
+++ b/apps/daimo-mobile/src/view/shared/OfflineHeader.tsx
@@ -1,5 +1,6 @@
 import Octicons from "@expo/vector-icons/Octicons";
 import { Platform, View } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import Spacer from "./Spacer";
@@ -12,9 +13,13 @@ import { useNetworkState } from "../../sync/networkState";
 export function OfflineHeader({
   dontTakeUpSpace,
   offlineExtraMarginBottom,
+  onPress,
+  title,
 }: {
   dontTakeUpSpace?: boolean;
   offlineExtraMarginBottom?: number;
+  onPress?(): void;
+  title?: string;
 }) {
   const netState = useNetworkState();
   const isOffline = netState.status === "offline";
@@ -44,13 +49,21 @@ export function OfflineHeader({
           <Spacer h={16} />
         ) /* Some Androids have a camera excluded from the safe insets. */
       }
-      {isOffline && (
-        <TextBody color={color.midnight}>
-          <Octicons name="alert" size={14} />
-          <Spacer w={8} />
-          Offline
-        </TextBody>
-      )}
+      <TouchableOpacity disabled={!onPress} onPress={onPress}>
+        {title && (
+          <TextBody color={color.midnight}>
+            <Spacer w={8} />
+            {title}
+          </TextBody>
+        )}
+        {isOffline && !title && (
+          <TextBody color={color.midnight}>
+            <Octicons name="alert" size={14} />
+            <Spacer w={8} />
+            Offline
+          </TextBody>
+        )}
+      </TouchableOpacity>
       {isOffline && <Spacer h={8} />}
     </View>
   );


### PR DESCRIPTION
Closes #589

Make offline header turn on sync and show refresh control.

I created some small animation to smooth the transition but I don't know if it's worth it clean-code-wise so we can revert just one commit to remove it and make code a lot simpler but the refresh control will show a little more aggressively. Examples below:

With animation:

https://github.com/daimo-eth/daimo/assets/42337257/edaa7d57-006d-436a-8c6b-b3b0a0b76a73

Without animation:

https://github.com/daimo-eth/daimo/assets/42337257/fed06eec-f528-470d-9aa5-cd579db07cc6

