### PR TITLE
Move debug modal to navigation like broken deeplink modal

### DIFF
--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -1,25 +1,17 @@
-import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
-import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types";
 import { DefaultTheme, NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { useEffect } from "react";
+import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import RNShake from "react-native-shake";
 
-import { useSendDebugLog } from "./common/useSendDebugLog";
 import { useInitNotifications } from "./logic/notify";
 import { RpcProvider } from "./logic/trpc";
 import { useAccount } from "./model/account";
 import { TabNav } from "./view/TabNav";
-import { ButtonMed } from "./view/shared/Button";
-import ScrollPellet from "./view/shared/ScrollPellet";
-import Spacer from "./view/shared/Spacer";
 import { color } from "./view/shared/style";
-import { TextH3, TextLight } from "./view/shared/text";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -56,64 +48,10 @@ export default function App() {
 }
 
 function AppBody() {
-  const bottomSheetRef = useRef<BottomSheet>(null);
-  const [isDebugModalOpen, setIsDebugModalOpen] = useState(false);
-
-  const snapPoints = useMemo(() => ["33%"], []);
-
-  useEffect(() => {
-    const subscription = RNShake.addListener(() => {
-      bottomSheetRef.current?.expand();
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, []);
-
-  const renderBackdrop = useCallback(
-    (props: BottomSheetDefaultBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        disappearsOnIndex={-0.9}
-        appearsOnIndex={0}
-        pressBehavior="close"
-      />
-    ),
-    []
-  );
-
-  const onChangeIndex = (index: number) => setIsDebugModalOpen(index > -1);
-
-  const [sendDL] = useSendDebugLog();
-
   return (
     <SafeAreaProvider>
       <TabNav />
       <StatusBar style="auto" />
-      <View
-        style={styles.bottomSheetWrapper}
-        pointerEvents={isDebugModalOpen ? "auto" : "none"}
-      >
-        <BottomSheet
-          handleComponent={ScrollPellet}
-          backdropComponent={renderBackdrop}
-          ref={bottomSheetRef}
-          index={-1}
-          snapPoints={snapPoints}
-          onChange={onChangeIndex}
-          enablePanDownToClose
-        >
-          <View style={styles.contentContainer}>
-            <Spacer h={16} />
-            <TextH3>Did something go wrong?</TextH3>
-            <Spacer h={12} />
-            <TextLight>Help us realize what's going wrong.</TextLight>
-            <Spacer h={32} />
-            <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
-          </View>
-        </BottomSheet>
-      </View>
     </SafeAreaProvider>
   );
 }

--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -3,7 +3,6 @@ import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
-import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
@@ -55,16 +54,3 @@ function AppBody() {
     </SafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  contentContainer: {
-    flex: 1,
-    alignSelf: "center",
-    alignItems: "stretch",
-  },
-  bottomSheetWrapper: {
-    position: "absolute",
-    height: "100%",
-    width: "100%",
-  },
-});

--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -19,10 +19,8 @@ import {
 import { useEffect, useState } from "react";
 import { Animated, Platform } from "react-native";
 import { EdgeInsets, useSafeAreaInsets } from "react-native-safe-area-context";
-
 import RNShake from "react-native-shake";
-import { TAB_BAR_HEIGHT } from "../common/useTabBarHeight";
-import { useAccount } from "../model/account";
+
 import { AccountScreen } from "./screen/AccountScreen";
 import { AddDeviceScreen } from "./screen/AddDeviceScreen";
 import { AddPasskeyScreen } from "./screen/AddPasskeyScreen";
@@ -50,6 +48,8 @@ import {
   useNav,
 } from "./shared/nav";
 import { color } from "./shared/style";
+import { TAB_BAR_HEIGHT } from "../common/useTabBarHeight";
+import { useAccount } from "../model/account";
 
 const { add, multiply } = Animated;
 
@@ -85,10 +85,9 @@ export function TabNav() {
     if (isOnboarded && account == null) setIsOnboarded(false);
   }, [isOnboarded, account]);
 
-
   useEffect(() => {
     const subscription = RNShake.addListener(() => {
-      nav.navigate("DebugLogModal")
+      nav.navigate("DebugLogModal");
     });
 
     return () => {
@@ -141,9 +140,11 @@ export function TabNav() {
   };
 
   return (
-    <MainStack.Navigator initialRouteName={isOnboarded ? "MainTabNav" : "OnboardingScreen" }>
+    <MainStack.Navigator
+      initialRouteName={isOnboarded ? "MainTabNav" : "OnboardingScreen"}
+    >
       <MainStack.Group>
-      <MainStack.Screen
+        <MainStack.Screen
           name="OnboardingScreen"
           component={OnboardingScreen}
           options={{ headerShown: false }}

--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -82,7 +82,10 @@ export function TabNav() {
   const [isOnboarded, setIsOnboarded] = useState<boolean>(account != null);
   useEffect(() => {
     // This is a latch: if we clear the account, go back to onboarding.
-    if (isOnboarded && account == null) setIsOnboarded(false);
+    if (isOnboarded && account == null) {
+      setIsOnboarded(false)
+      nav.reset({ routes: [{ name: "OnboardingScreen" }] })
+    }
   }, [isOnboarded, account]);
 
   useEffect(() => {

--- a/apps/daimo-mobile/src/view/TabNav.tsx
+++ b/apps/daimo-mobile/src/view/TabNav.tsx
@@ -83,8 +83,8 @@ export function TabNav() {
   useEffect(() => {
     // This is a latch: if we clear the account, go back to onboarding.
     if (isOnboarded && account == null) {
-      setIsOnboarded(false)
-      nav.reset({ routes: [{ name: "OnboardingScreen" }] })
+      setIsOnboarded(false);
+      nav.reset({ routes: [{ name: "OnboardingScreen" }] });
     }
   }, [isOnboarded, account]);
 

--- a/apps/daimo-mobile/src/view/screen/DebugLogScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/DebugLogScreen.tsx
@@ -1,0 +1,51 @@
+import { StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { useSendDebugLog } from "../../common/useSendDebugLog";
+import { ButtonMed } from "../shared/Button";
+import ScrollPellet from "../shared/ScrollPellet";
+import Spacer from "../shared/Spacer";
+import { TextH3, TextLight } from "../shared/text";
+
+export function DebugLogScreen() {
+  const { bottom } = useSafeAreaInsets();
+
+  const [sendDL] = useSendDebugLog();
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={[
+          styles.contentContainer,
+          {
+            paddingBottom: 32 + bottom,
+          },
+        ]}
+      >
+      <ScrollPellet />
+      <Spacer h={16} />
+      <TextH3>Did something go wrong?</TextH3>
+      <Spacer h={12} />
+      <TextLight>Help us realize what's going wrong.</TextLight>
+      <Spacer h={32} />
+      <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "flex-end",
+  },
+  contentContainer: {
+    backgroundColor: "white",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+});

--- a/apps/daimo-mobile/src/view/screen/DebugLogScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/DebugLogScreen.tsx
@@ -22,13 +22,13 @@ export function DebugLogScreen() {
           },
         ]}
       >
-      <ScrollPellet />
-      <Spacer h={16} />
-      <TextH3>Did something go wrong?</TextH3>
-      <Spacer h={12} />
-      <TextLight>Help us realize what's going wrong.</TextLight>
-      <Spacer h={32} />
-      <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
+        <ScrollPellet />
+        <Spacer h={16} />
+        <TextH3>Did something go wrong?</TextH3>
+        <Spacer h={12} />
+        <TextLight>Help us realize what's going wrong.</TextLight>
+        <Spacer h={32} />
+        <ButtonMed type="subtle" title="Send debug log" onPress={sendDL} />
       </View>
     </View>
   );

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -5,6 +5,12 @@ import { addEventListener } from "expo-linking";
 import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 
+import { AllowNotificationsPage } from "./AllowNotificationsPage";
+import { CreateAccountPage } from "./CreateAccountPage";
+import { IntroPages } from "./IntroPages";
+import { InvitePage } from "./InvitePage";
+import { OnboardingHeader } from "./OnboardingHeader";
+import { UseExistingPage } from "./UseExistingPage";
 import { ActStatus } from "../../../action/actStatus";
 import { useLoadOrCreateEnclaveKey } from "../../../action/key";
 import { useCreateAccount } from "../../../action/useCreateAccount";
@@ -24,12 +30,6 @@ import {
   TextError,
   TextLight,
 } from "../../shared/text";
-import { AllowNotificationsPage } from "./AllowNotificationsPage";
-import { CreateAccountPage } from "./CreateAccountPage";
-import { IntroPages } from "./IntroPages";
-import { InvitePage } from "./InvitePage";
-import { OnboardingHeader } from "./OnboardingHeader";
-import { UseExistingPage } from "./UseExistingPage";
 
 type OnboardPage =
   | "intro"
@@ -98,12 +98,7 @@ export default function OnboardingScreen() {
   const { status: useExistingStatus, message: useExistingMessage } =
     useExistingAccount(daimoChain, keyStatus, startedCreating);
 
-  const existingNext = getNext(
-    "existing",
-    goTo,
-    setDaimoChain,
-    nav
-  );
+  const existingNext = getNext("existing", goTo, setDaimoChain, nav);
 
   const reset = () => {
     pageStack.length = 0;

--- a/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/OnboardingScreen.tsx
@@ -5,12 +5,6 @@ import { addEventListener } from "expo-linking";
 import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 
-import { AllowNotificationsPage } from "./AllowNotificationsPage";
-import { CreateAccountPage } from "./CreateAccountPage";
-import { IntroPages } from "./IntroPages";
-import { InvitePage } from "./InvitePage";
-import { OnboardingHeader } from "./OnboardingHeader";
-import { UseExistingPage } from "./UseExistingPage";
 import { ActStatus } from "../../../action/actStatus";
 import { useLoadOrCreateEnclaveKey } from "../../../action/key";
 import { useCreateAccount } from "../../../action/useCreateAccount";
@@ -21,6 +15,7 @@ import { NamedError } from "../../../logic/log";
 import { defaultEnclaveKeyName } from "../../../model/account";
 import { ButtonBig } from "../../shared/Button";
 import Spacer from "../../shared/Spacer";
+import { MainNav, useNav } from "../../shared/nav";
 import { color, ss } from "../../shared/style";
 import {
   EmojiToOcticon,
@@ -29,6 +24,12 @@ import {
   TextError,
   TextLight,
 } from "../../shared/text";
+import { AllowNotificationsPage } from "./AllowNotificationsPage";
+import { CreateAccountPage } from "./CreateAccountPage";
+import { IntroPages } from "./IntroPages";
+import { InvitePage } from "./InvitePage";
+import { OnboardingHeader } from "./OnboardingHeader";
+import { UseExistingPage } from "./UseExistingPage";
 
 type OnboardPage =
   | "intro"
@@ -41,11 +42,7 @@ type OnboardPage =
   | "existing-allow-notifications"
   | "new-loading";
 
-export default function OnboardingScreen({
-  onOnboardingComplete,
-}: {
-  onOnboardingComplete: () => void;
-}) {
+export default function OnboardingScreen() {
   // Navigation with a back button
   // TODO: consider splitting into components and just using StackNavigation
   const [page, setPage] = useState<OnboardPage>("intro");
@@ -56,8 +53,9 @@ export default function OnboardingScreen({
   };
   const goToPrev = () => pageStack.length > 0 && setPage(pageStack.pop()!);
   const [daimoChain, setDaimoChain] = useState<DaimoChain>("base");
+  const nav = useNav();
 
-  const next = getNext(page, goTo, setDaimoChain, onOnboardingComplete);
+  const next = getNext(page, goTo, setDaimoChain, nav);
   const prev = pageStack.length === 0 ? undefined : goToPrev;
   // User enters their name
   const [name, setName] = useState("");
@@ -104,7 +102,7 @@ export default function OnboardingScreen({
     "existing",
     goTo,
     setDaimoChain,
-    onOnboardingComplete
+    nav
   );
 
   const reset = () => {
@@ -181,7 +179,7 @@ function getNext(
   page: OnboardPage,
   goToPage: (p: OnboardPage) => void,
   setDaimoChain: (daimoChain: DaimoChain) => void,
-  onOnboardingComplete: () => void
+  nav: MainNav
 ): ({
   choice,
   isTestnet,
@@ -222,7 +220,7 @@ function getNext(
       return fnGoTo("new-loading");
     case "existing-allow-notifications":
     case "new-loading":
-      return onOnboardingComplete;
+      return () => nav.reset({ routes: [{ name: "MainTabNav" }] });
     default:
       throw new Error(`unreachable ${page}`);
   }

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -2,13 +2,13 @@ import {
   DaimoLink,
   DaimoLinkAccount,
   DaimoLinkNote,
-  DaimoLinkRequest,
-  EAccount,
-  DisplayOpEvent,
-  parseDaimoLink,
   DaimoLinkNoteV2,
-  DaimoLinkTag,
+  DaimoLinkRequest,
   DaimoLinkRequestV2,
+  DaimoLinkTag,
+  DisplayOpEvent,
+  EAccount,
+  parseDaimoLink,
 } from "@daimo/common";
 import { NavigatorScreenParams, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -37,11 +37,15 @@ type ParamListError = {
 
 export type ParamListMain = {
   MainTabNav: ParamListTab;
+  OnboardingScreen: ParamListTab;
   LinkErrorModal: ParamListError;
+  DebugLogModal: undefined;
 };
 
 type NavigatorParamList = {
+  MainTabNav: ParamListTab;
   LinkErrorModal: ParamListError;
+  DebugLogModal: undefined;
   DepositTab: undefined;
   ReceiveTab: NavigatorScreenParams<ParamListReceive>;
   HomeTab: NavigatorScreenParams<ParamListHome>;

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -44,6 +44,7 @@ export type ParamListMain = {
 
 type NavigatorParamList = {
   MainTabNav: ParamListTab;
+  OnboardingScreen: ParamListTab;
   LinkErrorModal: ParamListError;
   DebugLogModal: undefined;
   DepositTab: undefined;


### PR DESCRIPTION
Origin in this conversation: https://github.com/daimo-eth/daimo/pull/649#discussion_r1481145749

Moved debug modal to navigation so we can open it anywhere using `nav.navigate()`
As a result I got to move onboarding and main tab to the same navigation as well so the modal is available anywhere in the app.

I don't know if we want to take such trade to improve a code a little so feel free to close this PR if we don't want it right now

Android:

https://github.com/daimo-eth/daimo/assets/42337257/3a142f8e-5834-4a2c-bd8f-d67e5ddb9c01


iOS:

https://github.com/daimo-eth/daimo/assets/42337257/2643a6f5-6606-4933-a787-4c218af26eef