### PR TITLE
mobile: make contact search unique, fix list key bug

### DIFF
--- a/apps/daimo-mobile/src/logic/daimoContacts.ts
+++ b/apps/daimo-mobile/src/logic/daimoContacts.ts
@@ -45,6 +45,20 @@ export type DaimoContact = EAccountContact | EmailContact | PhoneNumberContact;
 // on-chain account)
 export type MsgContact = EmailContact | PhoneNumberContact;
 
+// Get a unique key for a DaimoContact, used for component key.
+// EAccounts are unique by address, emails and phone numbers are unique by
+// email or phone number, guaranteed by our systemContacts search function.
+export function getDaimoContactKey(contact: DaimoContact): string {
+  switch (contact.type) {
+    case "eAcc":
+      return contact.addr;
+    case "email":
+      return contact.email;
+    case "phoneNumber":
+      return contact.phoneNumber;
+  }
+}
+
 /** Convert EAccount to EAccountContact */
 export function addLastSendTime(
   account: Account,

--- a/apps/daimo-mobile/src/logic/systemContacts.ts
+++ b/apps/daimo-mobile/src/logic/systemContacts.ts
@@ -102,6 +102,10 @@ async function askOpenSettings(resolve: (value: void) => void) {
   );
 }
 
+// Search user system contacts for a string, returning a list of matches.
+// User's system contacts can be messy, so we show at most one email and
+// at most one phone number per contact. Additionally, skip duplicate phone
+// numbers or emails across two different contact names.
 export function useSystemContactsSearch(
   prefix: string,
   enabled: boolean
@@ -122,9 +126,13 @@ export function useSystemContactsSearch(
         const name = contact.name;
         if (name == null) continue;
 
-        // Show at most one email and one phone number per contact.
         for (const phone of contact.phoneNumbers ?? []) {
-          if (phone.number) {
+          if (
+            phone.number &&
+            !matches.some(
+              (c) => c.type === "phoneNumber" && c.phoneNumber === phone.number
+            )
+          ) {
             matches.push({
               type: "phoneNumber",
               phoneNumber: phone.number,
@@ -135,7 +143,10 @@ export function useSystemContactsSearch(
         }
 
         for (const email of contact.emails ?? []) {
-          if (email.email) {
+          if (
+            email.email &&
+            !matches.some((c) => c.type === "email" && c.email === email.email)
+          ) {
             matches.push({ type: "email", email: email.email, name });
             break;
           }

--- a/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
@@ -14,6 +14,7 @@ import {
   DaimoContact,
   EAccountContact,
   getContactName,
+  getDaimoContactKey,
   useRecipientSearch,
 } from "../../../logic/daimoContacts";
 import { ContactsAccess } from "../../../logic/systemContacts";
@@ -95,8 +96,12 @@ function SearchResultsScroll({
           </TextLight>
         </View>
       )}
-      {res.recipients.map((r, index) => (
-        <RecipientRow key={index} recipient={r} {...{ lagAutoFocus, mode }} />
+      {res.recipients.map((r) => (
+        <RecipientRow
+          key={getDaimoContactKey(r)}
+          recipient={r}
+          {...{ lagAutoFocus, mode }}
+        />
       ))}
       {res.status === "success" &&
         res.recipients.length === 0 &&


### PR DESCRIPTION
Tested on iOS simulator with:
- Two system contacts with same name, different email -> both show up and clickthrough correctly
- Two system contacts with same name, same email -> one shows up and click through correctly
- Two system contacts with different name, same email -> only one shows up and click through correctly