### PR TITLE
api: fix Farcaster link not showing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
           version: nightly
 
       - run: |
-          forge test -vvv --fork-url "https://base-sepolia.publicnode.com"
-          forge coverage --report lcov --fork-url "https://base-sepolia.publicnode.com"
+          forge test -vvv --fork-url "https://base-sepolia-rpc.publicnode.com"
+          forge coverage --report lcov --fork-url "https://base-sepolia-rpc.publicnode.com"
           git diff --exit-code
         working-directory: ./packages/contract
 

--- a/apps/scratchpad/src/index.ts
+++ b/apps/scratchpad/src/index.ts
@@ -1,3 +1,4 @@
+import { ProfileCache } from "@daimo/api/src/api/profile";
 import { CoinIndexer } from "@daimo/api/src/contract/coinIndexer";
 import { NameRegistry } from "@daimo/api/src/contract/nameRegistry";
 import { NoteIndexer } from "@daimo/api/src/contract/noteIndexer";
@@ -60,7 +61,8 @@ async function metrics() {
   console.log(`[METRICS] using wallet ${vc.walletClient.account.address}`);
   const db = new DB();
   const inviteGraph = new InviteGraph(db);
-  const nameReg = new NameRegistry(vc, inviteGraph, new Set([]));
+  const profileCache = new ProfileCache(vc, db);
+  const nameReg = new NameRegistry(vc, inviteGraph, profileCache, new Set([]));
   const opIndexer = new OpIndexer();
   const noteIndexer = new NoteIndexer(nameReg);
   const requestIndexer = new RequestIndexer(nameReg);

--- a/packages/daimo-api/src/api/search.ts
+++ b/packages/daimo-api/src/api/search.ts
@@ -36,17 +36,6 @@ export async function search(
     ret = dAccounts.map((d) => ({ ...d, originalMatch: d.name }));
   }
 
-  // Add linked accounts to search results
-  for (const r of ret) {
-    r.linkedAccounts = profileCache.getLinkedAccounts(r.addr);
-  }
-  const linkedAccountsRes = await profileCache.searchLinkedAccounts(prefix);
-  for (const l of linkedAccountsRes) {
-    const addr = getAddress(l.addr);
-    const eAcc = await nameReg.getEAccount(addr);
-    ret.push({ ...eAcc, linkedAccounts: [l.linkedAccount], originalMatch: "" });
-  }
-
   console.log(`[API] search: ${ret.length} results for '${prefix}'`);
   return ret;
 }

--- a/packages/daimo-api/src/contract/nameRegistry.ts
+++ b/packages/daimo-api/src/contract/nameRegistry.ts
@@ -19,6 +19,7 @@ import {
 } from "viem";
 import { normalize } from "viem/ens";
 
+import { ProfileCache } from "../api/profile";
 import { chainConfig } from "../env";
 import { ViemClient } from "../network/viemClient";
 import { InviteGraph } from "../offchain/inviteGraph";
@@ -42,6 +43,7 @@ const specialAddrLabels: { [_: Address]: AddrLabel } = {
   // Known Coinbase Pay addresses on Base
   "0x20FE51A9229EEf2cF8Ad9E89d91CAb9312cF3b7A": AddrLabel.Coinbase,
   "0x6dcBCe46a8B494c885D0e7b6817d2b519dF64467": AddrLabel.Coinbase,
+  "0x1985EA6E9c68E1C272d8209f3B478AC2Fdb25c87": AddrLabel.Coinbase,
 };
 
 specialAddrLabels[chainConfig.pimlicoPaymasterAddress] = AddrLabel.Paymaster;
@@ -64,6 +66,7 @@ export class NameRegistry {
   constructor(
     private vc: ViemClient,
     private inviteGraph: InviteGraph,
+    private profileCache: ProfileCache,
     private nameBlacklist: Set<string>
   ) {}
 
@@ -163,7 +166,8 @@ export class NameRegistry {
     if (reg) {
       const { addr, name, timestamp } = reg;
       const inviter = this.inviteGraph.getInviter(address);
-      return { addr, name, timestamp, inviter } as EAccount;
+      const linkedAccounts = this.profileCache.getLinkedAccounts(addr);
+      return { addr, name, timestamp, inviter, linkedAccounts } as EAccount;
     }
 
     // Then, a special labelled address, e.g. faucet

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -37,11 +37,13 @@ async function main() {
 
   console.log(`[API] using wallet ${vc.walletClient.account.address}`);
   const inviteGraph = new InviteGraph(db);
+  const profileCache = new ProfileCache(vc, db);
 
   const keyReg = new KeyRegistry();
   const nameReg = new NameRegistry(
     vc,
     inviteGraph,
+    profileCache,
     await db.loadNameBlacklist()
   );
   const inviteCodeTracker = new InviteCodeTracker(vc, nameReg, db);
@@ -80,8 +82,6 @@ async function main() {
     requestIndexer,
     opIndexer
   );
-
-  const profileCache = new ProfileCache(vc, db);
 
   // Initialize in background
   (async () => {

--- a/packages/daimo-api/test/bundleCompression.test.ts
+++ b/packages/daimo-api/test/bundleCompression.test.ts
@@ -13,7 +13,12 @@ import {
 /// For the opposite test, see BundleBulker.t.sol in the bulk repo.
 test("compress example bundle", () => {
   // from, to must both be named accounts
-  const nameReg = new NameRegistry(null as any, null as any, new Set([]));
+  const nameReg = new NameRegistry(
+    null as any,
+    null as any,
+    null as any,
+    new Set([])
+  );
   nameReg.onSuccessfulRegister(
     "alice",
     "0x8bFfa71A959AF0b15C6eaa10d244d80BF23cb6A2"

--- a/packages/daimo-api/test/dtest.ts
+++ b/packages/daimo-api/test/dtest.ts
@@ -10,7 +10,12 @@ import { Watcher } from "../src/shovel/watcher";
 async function main() {
   const vc = getViemClientFromEnv();
   const opIndexer = new OpIndexer();
-  const nameReg = new NameRegistry(vc, null as any, new Set<string>());
+  const nameReg = new NameRegistry(
+    vc,
+    null as any,
+    null as any,
+    new Set<string>()
+  );
   const noteIndexer = new NoteIndexer(nameReg);
   const requestIndexer = new RequestIndexer(nameReg);
   const coinIndexer = new CoinIndexer(


### PR DESCRIPTION
Tested on iOS simulator, looks like we weren't attaching the linkedAccounts to `EAccount`s from some API requests before -- this is nice because it gives us a negative diff also