### PR TITLE
release: 1.6.0

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.6.0";
+const VERSION = "1.6.1";
 
 const config: ExpoConfig = {
   owner: "daimo",

--- a/apps/daimo-mobile/src/view/shared/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/shared/HistoryList.tsx
@@ -164,6 +164,9 @@ function HeaderRow({ title }: { title: string }) {
   );
 }
 
+// Gets the logical from and to-addresses for a given op
+// If the op creates a payment link, to = payment link until claimed, then it's
+// the address of the claimer.
 function getFromTo(op: DisplayOpEvent): [Address, Address] {
   if (op.type === "transfer") {
     return [op.from, op.to];
@@ -217,6 +220,18 @@ function DisplayOpRow({
 
   const isPending = displayOp.status === OpStatus.pending;
   const textCol = isPending ? color.gray3 : color.midnight;
+
+  // Title = counterparty name
+  let opTitle = getAccountName(otherAcc);
+  if (
+    opTitle === AddrLabel.PaymentLink &&
+    displayOp.type === "claimLink" &&
+    displayOp.noteStatus.sender.addr === address &&
+    displayOp.noteStatus.claimer?.addr === address
+  ) {
+    // Special case: we cancelled our own payment link
+    opTitle = "cancelled link";
+  }
 
   return (
     <View style={styles.transferBorder}>


### PR DESCRIPTION
<!-- PR TITLE -->
<!-- release v1.2.3 build 101 -->
<!-- Build number should be identical across both platforms. -->

**Fresh new look. Link Farcaster.**


## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly
- [x] Logs look clean

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account. Faucet should appear automatically > no faucet on Sepolia, used faucet.circle.com
- [x] Send payment
- [x] Create Payment Link, open in browser
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Create Request, open in browser
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Connect Farcaster. **Ran into connect farcaster 'Request failed, Offline?' bug.**
- [x] Debug log looks mostly clean. Errors related to above farcaster auth-client issue.

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account
- [x] Request faucet
- [x] Notification appears on faucet send
- [x] Send payment
- [x] Create Payment Link
- [x] Cancel Payment Link. **Can't, "gas too high to claim". Not an issue in prod.**
- [x] Tap Payment Link, ensure it opens in-app
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device
- [x] Create Request
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### Push to prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean
- [x] Honeycomb clean. Clean, usual errors in `getLinkStatus` / invite codes Android fuzzing and health check endpoint on startup.

### Prod smoke test

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.

### Promote release

BEFORE merging this PR,

- [x] Push to public TestFlight + Play Store open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
