### PR TITLE
mobile: include recent senders in search, improve /l/invite 

### DIFF
--- a/apps/daimo-mobile/src/logic/daimoContacts.ts
+++ b/apps/daimo-mobile/src/logic/daimoContacts.ts
@@ -122,7 +122,7 @@ export function useRecipientSearch(
     recentsByAddr.set(other, r);
   }
 
-  // Always show recent recipients first
+  // Always show recent contacts first
   const recipients: DaimoContact[] = [];
   const looseMatchRecents: DaimoContact[] = [];
   for (const r of recents) {

--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { ActivityIndicator, Linking, StyleSheet, View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 
-import { addLastSendTime } from "../../logic/daimoContacts";
+import { addLastSendRecvTime } from "../../logic/daimoContacts";
 import { env } from "../../logic/env";
 import { useFetchLinkStatus } from "../../logic/linkStatus";
 import { Account } from "../../model/account";
@@ -147,7 +147,7 @@ function AccountScreenBody({
 
   const canSend = canSendTo(eAcc);
   const send = useCallback(() => {
-    const recipient = addLastSendTime(account, eAcc);
+    const recipient = addLastSendRecvTime(account, eAcc);
     nav.navigate("SendTab", {
       screen: "SendTransfer",
       params: { recipient },

--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -1,5 +1,5 @@
-import { getTeamDaimoFaucetAcc } from "@daimo/api/src/contract/nameRegistry";
 import {
+  AddrLabel,
   DaimoLinkAccount,
   DaimoLinkInviteCode,
   EAccount,
@@ -9,7 +9,7 @@ import {
   getAddressContraction,
   timeMonth,
 } from "@daimo/common";
-import { daimoChainFromId } from "@daimo/contract";
+import { daimoChainFromId, teamDaimoFaucetAddr } from "@daimo/contract";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useCallback, useEffect, useRef } from "react";
 import { ActivityIndicator, Linking, StyleSheet, View } from "react-native";
@@ -124,6 +124,10 @@ function AccountScreenLoader({
       )}
     </View>
   );
+}
+
+function getTeamDaimoFaucetAcc(): EAccount {
+  return { addr: teamDaimoFaucetAddr, label: AddrLabel.Faucet };
 }
 
 function AccountScreenBody({

--- a/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
@@ -83,9 +83,7 @@ function SearchResultsScroll({
       )}
       {res.recipients.length > 0 && (
         <View style={styles.resultsHeader}>
-          <TextLight>
-            {recentsOnly ? "Recent recipients" : "Search results"}
-          </TextLight>
+          <TextLight>{recentsOnly ? "Recents" : "Search results"}</TextLight>
         </View>
       )}
       {res.recipients.map((r) => (
@@ -164,15 +162,17 @@ function RecipientRow({
         return recipient.name ? recipient.phoneNumber : undefined;
       case "eAcc": {
         const nowS = now();
-        return recipient.lastSendTime
-          ? `Sent ${timeAgo(recipient.lastSendTime, nowS, true)}`
-          : undefined;
+        const { lastSendTime, lastRecvTime } = recipient;
+        if (lastSendTime) return `Sent ${timeAgo(lastSendTime, nowS, true)}`;
+        if (lastRecvTime)
+          return `Received ${timeAgo(lastRecvTime, nowS, true)}`;
+        return undefined;
       }
     }
   })();
   const shortenedLightText =
-    lightText && lightText?.length > 15
-      ? lightText.slice(0, 15) + "…"
+    lightText && lightText?.length > 17
+      ? lightText.slice(0, 16) + "…"
       : lightText;
 
   return (

--- a/apps/daimo-mobile/src/view/screen/send/SendTransferScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendTransferScreen.tsx
@@ -19,7 +19,7 @@ import { RecipientDisplay } from "./RecipientDisplay";
 import { SendTransferButton } from "./SendTransferButton";
 import {
   EAccountContact,
-  addLastSendTime,
+  addLastSendRecvTime,
   getContactName,
 } from "../../../logic/daimoContacts";
 import { useFetchLinkStatus } from "../../../logic/linkStatus";
@@ -79,29 +79,22 @@ function SendScreenInner({
       else if (requestFetch.error)
         return <ErrorRowCentered error={requestFetch.error} />;
       else if (requestStatus) {
+        const recipient = addLastSendRecvTime(account, requestStatus.recipient);
         if (requestStatus.link.type === "requestv2") {
-          const recipientContact = addLastSendTime(
-            account,
-            requestStatus.recipient
-          );
           return (
             <SendConfirm
               account={account}
-              recipient={recipientContact}
+              recipient={recipient}
               dollars={requestStatus.link.dollars}
               requestStatus={requestStatus as DaimoRequestV2Status}
             />
           );
         } else {
           // Backcompat with old request links
-          const recipientContact = addLastSendTime(
-            account,
-            requestStatus.recipient
-          );
           return (
             <SendConfirm
               account={account}
-              recipient={recipientContact}
+              recipient={recipient}
               dollars={requestStatus.link.dollars}
             />
           );

--- a/apps/daimo-mobile/src/view/shared/error.tsx
+++ b/apps/daimo-mobile/src/view/shared/error.tsx
@@ -111,5 +111,6 @@ const styles = StyleSheet.create({
   buttonContainer: {
     width: "100%",
     marginTop: 24,
+    paddingHorizontal: 24,
   },
 });

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -1,6 +1,7 @@
 import {
   DaimoLink,
   DaimoLinkAccount,
+  DaimoLinkInviteCode,
   DaimoLinkNote,
   DaimoLinkNoteV2,
   DaimoLinkRequest,
@@ -8,8 +9,8 @@ import {
   DaimoLinkTag,
   DisplayOpEvent,
   EAccount,
-  parseDaimoLink,
   getEAccountStr,
+  parseDaimoLink,
 } from "@daimo/common";
 import { NavigatorScreenParams, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -25,7 +26,7 @@ export type ParamListHome = {
   QR: { option: QRScreenOptions | undefined };
   Account:
     | { eAcc: EAccount; inviterEAcc: EAccount | undefined }
-    | { link: DaimoLinkAccount };
+    | { link: DaimoLinkAccount | DaimoLinkInviteCode };
   HistoryOp: { op: DisplayOpEvent };
 };
 
@@ -168,6 +169,10 @@ async function goTo(nav: MainNav, link: DaimoLink) {
     }
     case "tag": {
       nav.navigate("SendTab", { screen: "SendTransfer", params: { link } });
+      break;
+    }
+    case "invite": {
+      nav.navigate("HomeTab", { screen: "Account", params: { link } });
       break;
     }
     default:

--- a/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
+++ b/apps/daimo-web/src/app/[...topLevelPage]/route.tsx
@@ -6,7 +6,13 @@ export async function GET(request: Request) {
   // Special case: /waitlist
   if (url.pathname === "/waitlist") {
     // redirect to waitlist noteform for now
-    return Response.redirect("https://noteforms.com/forms/daimo-uk2fe4", 301);
+    return Response.redirect("https://noteforms.com/forms/daimo-uk2fe4", 302);
+  }
+
+  // Redirect daimo.xyz to daimo.com
+  if (url.hostname === "daimo.xyz") {
+    url.hostname = "daimo.com";
+    return Response.redirect(url, 301);
   }
 
   // Otherwise proxy the request to our notion super.so

--- a/packages/daimo-api/src/contract/nameRegistry.ts
+++ b/packages/daimo-api/src/contract/nameRegistry.ts
@@ -28,7 +28,6 @@ import { InviteGraph } from "../offchain/inviteGraph";
 import { retryBackoff } from "../utils/retryBackoff";
 
 export const specialAddrLabels: { [_: Address]: AddrLabel } = {
-  "0x2A6d311394184EeB6Df8FBBF58626B085374Ffe7": AddrLabel.Faucet,
   // All historical notes ("payment link") contract addresses
   "0x37Ac8550dA1E8d227266966A0b4925dfae648f7f": AddrLabel.PaymentLink,
   "0x450E09fc6C2a9bC4230D4e6f3d7131CCa48b48Ce": AddrLabel.PaymentLink,
@@ -47,6 +46,12 @@ export const specialAddrLabels: { [_: Address]: AddrLabel } = {
   "0x6dcBCe46a8B494c885D0e7b6817d2b519dF64467": AddrLabel.Coinbase,
   "0x1985EA6E9c68E1C272d8209f3B478AC2Fdb25c87": AddrLabel.Coinbase,
 };
+
+const teamDaimoFaucetAddr = "0x2a6d311394184EeB6Df8FBBF58626B085374Ffe7";
+specialAddrLabels[teamDaimoFaucetAddr] = AddrLabel.Faucet;
+export function getTeamDaimoFaucetAcc(): EAccount {
+  return { addr: teamDaimoFaucetAddr, label: AddrLabel.Faucet };
+}
 
 specialAddrLabels[chainConfig.pimlicoPaymasterAddress] = AddrLabel.Paymaster;
 

--- a/packages/daimo-contract/src/index.ts
+++ b/packages/daimo-contract/src/index.ts
@@ -16,6 +16,8 @@ export const pimlicoPaymasterAbi = parseAbi([
   "function token() view returns (address)",
 ]);
 
+export const teamDaimoFaucetAddr = "0x2a6d311394184EeB6Df8FBBF58626B085374Ffe7";
+
 export {
   daimoAccountABI,
   daimoRequestABI,


### PR DESCRIPTION
* show inviter when opening invite deeplink
  * currently you just stay on the home screen, which feels like a bug
* include recent senders in search

### Recent senders show up

Before this PR, this list would've been empty. (No recent recipients, 1 recent sender, now shown:)

<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/b6d94cc9-308b-43dc-aa37-4fd04a58a14a">

### "First time paying" warning is still there

If someone has paid you but you've never paid them before, you see the following:

<img width="250" alt="Screenshot 2024-03-05 at 18 49 17" src="https://github.com/daimo-eth/daimo/assets/169280/92ee7805-89da-4946-a130-2b92cd81ae11">
