### PR TITLE
Push account screens correctly

### DIFF
--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -86,9 +86,9 @@ function AccountScreenLoader({
     if (status.data == null) return;
     if (!("account" in status.data)) return;
     console.log(`[ACCOUNT] loaded account: ${JSON.stringify(status.data)}`);
-    nav.navigate("HomeTab", {
-      screen: "Account",
-      params: { eAcc: status.data.account, inviterEAcc: status.data.inviter },
+    nav.navigate("Account", {
+      eAcc: status.data.account,
+      inviterEAcc: status.data.inviter,
     });
   }, [status.data]);
 

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -191,8 +191,6 @@ export function useExitBack() {
 
 // Open account page within the same tab.
 export function navToAccountPage(account: EAccount, nav: MainNav) {
-  // Workaround: react-navigation typescript types are broken.
-  // currentTab is eg "SendNav", is NOT in fact a ParamListTab:
   const accountLink = {
     type: "account",
     account: getEAccountStr(account),

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -191,11 +191,10 @@ export function useExitBack() {
 export function navToAccountPage(account: EAccount, nav: MainNav) {
   // Workaround: react-navigation typescript types are broken.
   // currentTab is eg "SendNav", is NOT in fact a ParamListTab:
-  const currentTab = nav.getState().routes[0].name;
-  const newTab = currentTab.startsWith("Send") ? "SendTab" : "HomeTab";
   const accountLink = {
     type: "account",
     account: getEAccountStr(account),
   } as DaimoLinkAccount;
-  nav.navigate(newTab, { screen: "Account", params: { link: accountLink } });
+
+  nav.push("Account", { link: accountLink });
 }

--- a/apps/daimo-mobile/src/view/shared/nav.ts
+++ b/apps/daimo-mobile/src/view/shared/nav.ts
@@ -111,12 +111,14 @@ export type ParamListBottomSheet = {
   };
 };
 
-export function useNav<
-  RouteName extends keyof NavigatorParamList = keyof NavigatorParamList
->() {
-  return useNavigation<
-    NativeStackNavigationProp<NavigatorParamList, RouteName>
-  >();
+type AllRoutes = NavigatorParamList &
+  ParamListHome &
+  ParamListSend &
+  ParamListReceive &
+  ParamListSettings;
+
+export function useNav<RouteName extends keyof AllRoutes = keyof AllRoutes>() {
+  return useNavigation<NativeStackNavigationProp<AllRoutes, RouteName>>();
 }
 
 export type MainNav = ReturnType<typeof useNav>;


### PR DESCRIPTION
This PR fixes an issue where RN's `navigate` function replaces the account screen in-place instead of pushing a new one to the navigation stack. Swapping out `navigate` for `push` fixes the issue. It also fixes an issue where backward navigation on the `SendTab` screen incorrectly navigated to the `HomeTab` screen.
