### PR TITLE
Prevent address repeat in subtitle

### DIFF
--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -200,11 +200,7 @@ function AccountScreenBody({
           Joined {timeMonth(eAcc.timestamp)}
         </TextBody>
       );
-    return (
-      <TextBody color={color.gray3}>
-        {getAddressContraction(eAcc.addr)}
-      </TextBody>
-    );
+    return null;
   })();
 
   // Show linked accounts

--- a/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/AccountScreen.tsx
@@ -200,6 +200,12 @@ function AccountScreenBody({
           Joined {timeMonth(eAcc.timestamp)}
         </TextBody>
       );
+    else if (getAccountName(eAcc) !== getAddressContraction(eAcc.addr))
+      return (
+        <TextBody color={color.gray3}>
+          {getAddressContraction(eAcc.addr)}
+        </TextBody>
+      );
     return null;
   })();
 


### PR DESCRIPTION
Closes #827 

This PR prevents address information from getting repeated in the account screen's subtitle.