### PR TITLE
Fix issue with profile picture flicker

### DIFF
--- a/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
+++ b/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
@@ -85,7 +85,6 @@ export function Bubble({
   fontSize: number;
   image?: string;
   children: React.ReactNode;
-  logPrefix?: string;
 }) {
   const col = isPending ? color.primaryBgLight : color.primary;
 

--- a/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
+++ b/apps/daimo-mobile/src/view/shared/ContactBubble.tsx
@@ -85,6 +85,7 @@ export function Bubble({
   fontSize: number;
   image?: string;
   children: React.ReactNode;
+  logPrefix?: string;
 }) {
   const col = isPending ? color.primaryBgLight : color.primary;
 
@@ -115,7 +116,6 @@ export function Bubble({
 
   const imageStyle: ImageStyle = useMemo(
     () => ({
-      position: "absolute",
       // Match size of bordered default bubble
       height: size - 1,
       width: size - 1,

--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -7,7 +7,15 @@ import {
   NativeStackNavigationOptions,
   createNativeStackNavigator,
 } from "@react-navigation/native-stack";
-import { ReactNode, forwardRef, useCallback, useMemo, useState } from "react";
+import {
+  ReactNode,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { Dimensions, StyleSheet } from "react-native";
 import Animated, {
   useAnimatedStyle,
@@ -112,18 +120,6 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
       };
     });
 
-    const TransactionList = () => (
-      <>
-        <Animated.View
-          style={[styles.itemMiniWrapper, itemMiniStyle]}
-          pointerEvents={isMini ? "auto" : "none"}
-        >
-          {itemMini}
-        </Animated.View>
-        {itemFull}
-      </>
-    );
-
     return (
       <BottomSheet
         index={0}
@@ -141,26 +137,63 @@ export const SwipeUpDown = forwardRef<SwipeUpDownRef, SwipeUpDownProps>(
         animationConfigs={ANIMATION_CONFIG}
       >
         <SetBottomSheetSnapPointCount.Provider value={setSnapPointCount}>
-          <BottomSheetStackNavigator.Navigator
-            initialRouteName="BottomSheetList"
-            screenOptions={noHeaders}
+          <SwipeContext.Provider
+            value={{ isMini, itemMiniStyle, itemMini, itemFull }}
           >
-            <BottomSheetStackNavigator.Group>
-              <BottomSheetStackNavigator.Screen
-                name="BottomSheetList"
-                component={TransactionList}
-              />
-              <BottomSheetStackNavigator.Screen
-                name="BottomSheetHistoryOp"
-                component={HistoryOpScreen}
-              />
-            </BottomSheetStackNavigator.Group>
-          </BottomSheetStackNavigator.Navigator>
+            <BottomSheetStackNavigator.Navigator
+              initialRouteName="BottomSheetList"
+              screenOptions={noHeaders}
+            >
+              <BottomSheetStackNavigator.Group>
+                <BottomSheetStackNavigator.Screen
+                  name="BottomSheetList"
+                  component={TransactionList}
+                />
+                <BottomSheetStackNavigator.Screen
+                  name="BottomSheetHistoryOp"
+                  component={HistoryOpScreen}
+                />
+              </BottomSheetStackNavigator.Group>
+            </BottomSheetStackNavigator.Navigator>
+          </SwipeContext.Provider>
         </SetBottomSheetSnapPointCount.Provider>
       </BottomSheet>
     );
   }
 );
+
+type SwipeContextValue = {
+  itemMini: ReactNode;
+  itemFull: ReactNode;
+  isMini: boolean;
+  itemMiniStyle: { opacity: number };
+};
+
+const SwipeContext = createContext<SwipeContextValue | null>(null);
+
+function useSwipeContext() {
+  const ctx = useContext(SwipeContext);
+
+  if (!ctx) throw new Error("Must be used inside a SwipeContext");
+
+  return ctx;
+}
+
+function TransactionList() {
+  const { itemMini, itemFull, isMini, itemMiniStyle } = useSwipeContext();
+
+  return (
+    <>
+      <Animated.View
+        style={[styles.itemMiniWrapper, itemMiniStyle]}
+        pointerEvents={isMini ? "auto" : "none"}
+      >
+        {itemMini}
+      </Animated.View>
+      {itemFull}
+    </>
+  );
+}
 
 const ANIMATION_CONFIG = {
   stiffness: 160,

--- a/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
+++ b/apps/daimo-mobile/src/view/shared/SwipeUpDown.tsx
@@ -179,6 +179,7 @@ function useSwipeContext() {
   return ctx;
 }
 
+// Fade animation between minified and full lists
 function TransactionList() {
   const { itemMini, itemFull, isMini, itemMiniStyle } = useSwipeContext();
 


### PR DESCRIPTION
This PR fixes an issue that caused profile images to flicker unnecessarily. The issue was caused by a fresh instantiation of `TransactionList` in `SwipeUpDown` on every render. Moving the component out and lifting state into a context fixed the issue.

## Testing

To properly test this PR, run it on a physical device. For some reason, the issue fixed is not reproducible on iOS simulators.