### PR TITLE
Passkeys: Retry backoff creation on domain association errors

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -25,12 +25,7 @@ const config: ExpoConfig = {
   ios: {
     supportsTablet: true,
     bundleIdentifier: IS_DEV ? "com.daimo.dev" : "com.daimo",
-    associatedDomains: [
-      "applinks:daimo.xyz",
-      "applinks:daimo.com",
-      "webcredentials:daimo.xyz",
-      "webcredentials:daimo.com",
-    ],
+    associatedDomains: ["applinks:daimo.com", "webcredentials:daimo.com"],
     config: {
       usesNonExemptEncryption: false,
     },

--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -14,6 +14,7 @@ import RNShake from "react-native-shake";
 
 import { Dispatcher, DispatcherContext } from "./action/dispatch";
 import { useInitNotifications } from "./logic/notify";
+import { prefetchAASA } from "./logic/passkey";
 import { RpcProvider } from "./logic/trpc";
 import { useAccount } from "./model/account";
 import { TabNav } from "./view/TabNav";
@@ -44,6 +45,10 @@ export default function App() {
     if (account == null || nowS - account.lastBlockTimestamp < 60 * 10) {
       SplashScreen.hideAsync();
     }
+
+    // Workaround for iOS bug with passkeys: prefetch AASA in background
+    // on loading app
+    prefetchAASA();
   }, []);
 
   return (

--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -14,7 +14,6 @@ import RNShake from "react-native-shake";
 
 import { Dispatcher, DispatcherContext } from "./action/dispatch";
 import { useInitNotifications } from "./logic/notify";
-import { prefetchAASA } from "./logic/passkey";
 import { RpcProvider } from "./logic/trpc";
 import { useAccount } from "./model/account";
 import { TabNav } from "./view/TabNav";
@@ -45,10 +44,6 @@ export default function App() {
     if (account == null || nowS - account.lastBlockTimestamp < 60 * 10) {
       SplashScreen.hideAsync();
     }
-
-    // Workaround for iOS bug with passkeys: prefetch AASA in background
-    // on loading app
-    prefetchAASA();
   }, []);
 
   return (

--- a/apps/daimo-mobile/src/logic/log.ts
+++ b/apps/daimo-mobile/src/logic/log.ts
@@ -45,18 +45,19 @@ export class Log {
     type: string,
     fn: () => Promise<T>,
     retries: number,
-    matchError?: (e: NamedError) => boolean
+    matchError?: (e: string) => boolean
   ) {
     for (let i = 0; i < retries; i++) {
-      const ret = fn();
       try {
-        this.promise(type, ret);
-        return ret;
+        return await this.promise(type, fn());
       } catch (e: any) {
-        if (matchError && matchError(e)) {
+        if (matchError && matchError(getErrMessage(e))) {
           console.log(`[LOG] ${type} trial ${i} error ${getErrMessage(e)}`);
-          setTimeout(() => {}, i * 300);
+          await new Promise((r) => setTimeout(r, 200 * 2 ** i));
         } else {
+          console.log(
+            `[LOG] ${type} skipping retry ${i} error ${getErrMessage(e)}`
+          );
           throw new NamedError(getErrMessage(e), type);
         }
       }

--- a/apps/daimo-mobile/src/logic/log.ts
+++ b/apps/daimo-mobile/src/logic/log.ts
@@ -56,7 +56,7 @@ export class Log {
           await new Promise((r) => setTimeout(r, 200 * 2 ** i));
         } else {
           console.log(
-            `[LOG] ${type} skipping retry ${i} error ${getErrMessage(e)}`
+            `[LOG] ${type} trial ${i}, quitting: ${getErrMessage(e)}`
           );
           throw new NamedError(getErrMessage(e), type);
         }

--- a/apps/daimo-mobile/src/logic/passkey.ts
+++ b/apps/daimo-mobile/src/logic/passkey.ts
@@ -15,6 +15,7 @@ import { env } from "./env";
 import { Log } from "./log";
 import { parseCreateResponse, parseSignResponse } from "./passkeyParsers";
 
+// Workaround iOS deeplinks bug: https://github.com/daimo-eth/daimo/issues/837
 function matchAASABugError(e: string) {
   // Match without english text since iOS errors are localized to device language
   return e.includes("JV8PYC9QV4.com.daimo") && e.includes("daimo.com");

--- a/apps/daimo-mobile/src/view/screen/keyRotation/AddKeySlotButton.tsx
+++ b/apps/daimo-mobile/src/view/screen/keyRotation/AddKeySlotButton.tsx
@@ -78,9 +78,7 @@ export function AddKeySlotButton({
     },
   });
 
-  const didUserCancel =
-    message.includes("User cancelled") || // Android
-    message.includes("User canceled"); // iOS
+  const didUserCancel = message.includes("User cancelled");
 
   const statusMessage = (function (): ReactNode {
     switch (status) {

--- a/packages/daimo-expo-passkeys/ios/PasskeyManager.swift
+++ b/packages/daimo-expo-passkeys/ios/PasskeyManager.swift
@@ -17,7 +17,7 @@ public class PasskeyManager {
         }
 
         if authError.code == .canceled {
-            return "User canceled auth request"
+            return "User cancelled auth request"
         } else {
             // The userInfo dictionary sometimes contains useful information.
             return "Error: \((error as NSError).userInfo)"


### PR DESCRIPTION
Tested it fixes the issue consistently, deleted app and reinstalled and immediately clicked restore from backup ~10 times.

Additionally, remove .xyz domains just in case they can cause issues.

Example log:

<img width="789" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/b7c258e2-fabf-4a9d-af0f-111d01789029">
