### PR TITLE
release: 1.7.0

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.7.0";
+const VERSION = "1.7.1";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
<!-- PR TITLE -->
<!-- release v1.2.3 build 101 -->
<!-- Build number should be identical across both platforms. -->

**Profile pics, invite tab, and more.**

<!-- Optional screenshot, 4-6 panels joined as described in scratchpad README. -->

## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly
- [x] Logs look clean

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account
- [x] Faucet + notification should appear automatically.
- [x] Send payment
- [x] Create Payment Link, open in browser
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app. **Nav froze once, worked after restart.**
- [x] Create Request, open in browser
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device. **Shows "Device removed" error page correctly on other device.**
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

<details>
<summary><strong>Debug log shows following error on device screen.</strong></summary>

```
2024-03-13T10:33:56.386Z log [APP] rendering
2024-03-13T10:33:56.389Z log [ERROR] rendering Cannot read property 'slot' of undefined TypeError: Cannot read property 'slot' of undefined
    at DeviceScreen (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:355135:23)
    at renderWithHooks (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:26724:24)
    at updateFunctionComponent (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:27409:32)
    at beginWork$1 (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:29336:215)
    at performUnitOfWork (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:28986:27)
    at workLoopSync (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:28980:55)
    at renderRootSync (/Users/expo/Library/Developer/Xcode/DerivedData/Daimo-fqyuburyhitsbcesjtzisutllqsr/Build/Intermediates.noindex/ArchiveIntermediates/Daimo/BuildProductsPath/Release-iphoneos/main.jsbundle:28966:19)
```

</details>

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account
- [x] Faucet + notification should appear automatically
- [x] Send payment
- [x] Create Payment Link
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Add device + Use existing onboarding (test transactions work on both devices). **Adding a device from Android didn't work on first try. iPhone (scanned device) stuck on "Existing Account" screen.**
- [x] Remove device
- [x] Create Request
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### ~macOS~

Skipping

### Push to prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean. **Logtail appears to be down.**
- [x] Honeycomb clean

### Prod smoke test

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation

**Prod account a bit slow on android, probably due to large history.**

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
