### PR TITLE
release: 1.7.1

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.7.1";
+const VERSION = "1.7.2";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
<!-- PR TITLE -->
<!-- release v1.2.3 build 101 -->
<!-- Build number should be identical across both platforms. -->

**Fixed onboarding.**


## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly
- [x] Logs look clean

### iOS

- [x] Install from TestFlight
- [x] Create account. Faucet should appear immediately as a pending op.
- [x] Send
- [x] Delete account
- [x] Add + remove device from Android, below.


### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account. **Strange bug where Accept Invite did not work at first > worked after app restart. Nothing obvious in debug log.**
- [x] Faucet + notification should appear automatically
- [x] Send payment
- [x] Create Payment Link
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app


### macOS

Smoke test.
- [x] ~Install from TestFlight~ requires OS update

### Push to prod

- [x] Push to `prod`
- [ ] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean
- [x] Honeycomb clean

### Prod smoke test
**This release fixes onboarding, so test that:**
- [x] Create account from payment link. Close app entirely > open by tapping link.
- [x] Once onboarding is done, pending link should appear immediately.
- [x] Delete account
- [x] Create account from invite. Open app > to to Use Existing > tap invite link > should deeplink over to choose name screen.
- [x] ~Once onboarding is done, invite faucet should appear immediately.~ **Can't test this due to device attestation > already used faucet on my phone.**
- [x] Delete account
- [x] Log back into prod account via passkey
- [x] Send a transfer
- [x] Notification appears on confirmation

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
