### PR TITLE
Don't close search when accidentally dismiss keyboard

### DIFF
--- a/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/HomeScreen.tsx
@@ -3,7 +3,6 @@ import Octicons from "@expo/vector-icons/Octicons";
 import { addEventListener } from "expo-linking";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  Dimensions,
   RefreshControl,
   StyleSheet,
   TouchableHighlight,
@@ -161,16 +160,14 @@ function HomeScreenInner({ account }: { account: Account }) {
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
-        contentContainerStyle={{
-          height: screenDimensions.height,
-        }}
+        contentContainerStyle={styles.animatedScrollContent}
         onScrollBeginDrag={onScrollBeginDrag}
         onScrollEndDrag={onScrollEndDrag}
         onScroll={scrollHandler}
         scrollEventThrottle={8}
         keyboardShouldPersistTaps="handled"
       >
-        <Animated.View style={preventOverscrollStyle}>
+        <Animated.View style={[preventOverscrollStyle, styles.scrollView]}>
           <Spacer h={Math.max(16, ins.top)} />
           {account.suggestedActions.length > 0 &&
             netState.status !== "offline" &&
@@ -312,8 +309,6 @@ function useInitNavLinks() {
   }, [accountMissing, nav]);
 }
 
-const screenDimensions = Dimensions.get("screen");
-
 const iconButton = {
   backgroundColor: color.primary,
   height: 64,
@@ -334,6 +329,12 @@ const styles = StyleSheet.create({
   amountAndButtons: {
     flexDirection: "column",
     alignItems: "center",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  animatedScrollContent: {
+    height: "100%",
   },
   buttonRow: {
     flexDirection: "row",

--- a/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SearchResults.tsx
@@ -1,5 +1,6 @@
 import { now, timeAgo } from "@daimo/common";
 import Octicons from "@expo/vector-icons/Octicons";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import * as Contacts from "expo-contacts";
 import { useCallback } from "react";
 import {
@@ -67,12 +68,13 @@ function SearchResultsScroll({
 
   const recentsOnly = prefix === "";
 
-  const kbH = useKeyboardHeight();
+  const kbH = useKeyboardHeight() - useBottomTabBarHeight();
 
   return (
     <ScrollView
       contentContainerStyle={styles.resultsScroll}
       keyboardShouldPersistTaps="handled"
+      style={styles.scrollView}
     >
       {res.error && <ErrorRowCentered error={res.error} />}
       {recentsOnly && contactsPermission && (
@@ -317,5 +319,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 16,
+  },
+  scrollView: {
+    height: "100%",
   },
 });

--- a/apps/daimo-mobile/src/view/shared/AnimatedSearchInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AnimatedSearchInput.tsx
@@ -1,5 +1,12 @@
 import Octicons from "@expo/vector-icons/Octicons";
-import { RefObject, useCallback, useRef, useState } from "react";
+import {
+  RefObject,
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import {
   Dimensions,
   LayoutChangeEvent,
@@ -28,125 +35,169 @@ const BACK_ICON = 30 + 8;
 
 const animationConfig = { duration: 150 };
 
-export function AnimatedSearchInput({
-  value,
-  onChange,
-  onFocus,
-  onBlur,
-  placeholder,
-  icon,
-  center,
-  autoFocus,
-  innerRef,
-  style,
-}: {
+interface AnimatedSearchInputProps {
   value: string;
   onChange: (value: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  onClose?: () => void;
   placeholder?: string;
   icon?: OctName;
   center?: boolean;
   autoFocus?: boolean;
   innerRef?: RefObject<TextInput>;
   style?: ViewStyle;
-}) {
-  const closedWidth = useSharedValue(INITIAL_WIDTH - ICONS);
-  const openWidth = useSharedValue(INITIAL_WIDTH - BACK_ICON);
-  const animatedWidth = useSharedValue(closedWidth.value);
-
-  const closedLeft = 0;
-  const openLeft = BACK_ICON / 2;
-  const animatedLeft = useSharedValue(closedLeft);
-
-  const [isFocused, setIsFocused] = useState(false);
-  const onInputFocus = useCallback(() => {
-    animatedWidth.value = withTiming(openWidth.value, animationConfig);
-    animatedLeft.value = withTiming(openLeft, animationConfig);
-    setIsFocused(true);
-    onFocus?.();
-  }, []);
-  const onInputBlur = useCallback(() => {
-    animatedWidth.value = withTiming(closedWidth.value, animationConfig);
-    animatedLeft.value = withTiming(closedLeft, animationConfig);
-    setIsFocused(false);
-    onBlur?.();
-  }, []);
-
-  // Android text input incorrectly autocapitalizes. Fix via password input.
-  const needsAndroidWorkaround = Platform.OS === "android";
-
-  const otherRef = useRef<TextInput>(null);
-  const wrapperRef = useAnimatedRef<View>();
-  const ref = innerRef || otherRef;
-  const focus = useCallback(() => {
-    ref.current?.focus();
-  }, [ref]);
-
-  const wrapperStyle = useAnimatedStyle(() => {
-    return {
-      width: animatedWidth.value,
-      left: animatedLeft.value,
-    };
-  });
-
-  const onLayout = (event: LayoutChangeEvent) => {
-    const newClosedWidth = event.nativeEvent.layout.width - ICONS;
-    const newOpenWidth = event.nativeEvent.layout.width - BACK_ICON;
-
-    closedWidth.value = newClosedWidth;
-    openWidth.value = newOpenWidth;
-
-    animatedWidth.value = isFocused ? newOpenWidth : newClosedWidth;
-    animatedLeft.value = isFocused ? openLeft : closedLeft;
-  };
-
-  return (
-    <View
-      style={styles.wrapperStyle}
-      ref={wrapperRef}
-      pointerEvents="box-none"
-      onLayout={onLayout}
-    >
-      <TouchableWithoutFeedback onPress={focus} hitSlop={8}>
-        <Animated.View
-          style={[
-            isFocused ? styles.inputRowFocused : styles.inputRow,
-            style,
-            wrapperStyle,
-          ]}
-        >
-          <TextInput
-            ref={ref}
-            placeholder={placeholder}
-            placeholderTextColor={color.grayMid}
-            value={value}
-            onChangeText={onChange}
-            style={center ? styles.inputCentered : styles.input}
-            multiline={Platform.OS === "android" && center}
-            numberOfLines={1}
-            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
-            autoCapitalize="none"
-            autoCorrect={false}
-            spellCheck={false}
-            autoFocus={autoFocus}
-            secureTextEntry={needsAndroidWorkaround}
-            keyboardType={
-              needsAndroidWorkaround ? "visible-password" : "default"
-            }
-            onFocus={onInputFocus}
-            onBlur={onInputBlur}
-          />
-          {icon && (
-            <Animated.View style={styles.inputIcon}>
-              <Octicons name={icon} size={18} color={color.primary} />
-            </Animated.View>
-          )}
-        </Animated.View>
-      </TouchableWithoutFeedback>
-    </View>
-  );
 }
+
+export type AnimatedSearchInputRef = {
+  openInput: () => void;
+  closeInput: () => void;
+};
+
+export const AnimatedSearchInput = forwardRef<
+  AnimatedSearchInputRef,
+  AnimatedSearchInputProps
+>(
+  (
+    {
+      value,
+      onChange,
+      onFocus,
+      onBlur,
+      onClose,
+      placeholder,
+      icon,
+      center,
+      autoFocus,
+      innerRef,
+      style,
+    },
+    ref
+  ) => {
+    const closedWidth = useSharedValue(INITIAL_WIDTH - ICONS);
+    const openWidth = useSharedValue(INITIAL_WIDTH - BACK_ICON);
+    const animatedWidth = useSharedValue(closedWidth.value);
+
+    const closedLeft = 0;
+    const openLeft = BACK_ICON / 2;
+    const animatedLeft = useSharedValue(closedLeft);
+
+    const animateOpenInput = () => {
+      animatedWidth.value = withTiming(openWidth.value, animationConfig);
+      animatedLeft.value = withTiming(openLeft, animationConfig);
+    };
+
+    const animateCloseInput = () => {
+      animatedWidth.value = withTiming(closedWidth.value, animationConfig);
+      animatedLeft.value = withTiming(closedLeft, animationConfig);
+    };
+
+    const [isFocused, setIsFocused] = useState(false);
+    const onInputFocus = useCallback(() => {
+      animateOpenInput();
+      setIsFocused(true);
+      onFocus?.();
+    }, []);
+    const onInputBlur = useCallback(() => {
+      if (value.length === 0) {
+        animateCloseInput();
+        onClose?.();
+      }
+      setIsFocused(false);
+      onBlur?.();
+    }, [value]);
+
+    // Android text input incorrectly autocapitalizes. Fix via password input.
+    const needsAndroidWorkaround = Platform.OS === "android";
+
+    const otherRef = useRef<TextInput>(null);
+    const wrapperRef = useAnimatedRef<View>();
+    const inputRef = innerRef || otherRef;
+    const focus = useCallback(() => {
+      inputRef.current?.focus();
+    }, [ref]);
+
+    useImperativeHandle(
+      ref,
+      () => {
+        return {
+          openInput() {
+            animateOpenInput();
+          },
+          closeInput() {
+            animateCloseInput();
+          },
+        };
+      },
+      []
+    );
+
+    const wrapperStyle = useAnimatedStyle(() => {
+      return {
+        width: animatedWidth.value,
+        left: animatedLeft.value,
+      };
+    });
+
+    const onLayout = (event: LayoutChangeEvent) => {
+      const newClosedWidth = event.nativeEvent.layout.width - ICONS;
+      const newOpenWidth = event.nativeEvent.layout.width - BACK_ICON;
+
+      closedWidth.value = newClosedWidth;
+      openWidth.value = newOpenWidth;
+
+      animatedWidth.value = isFocused ? newOpenWidth : newClosedWidth;
+      animatedLeft.value = isFocused ? openLeft : closedLeft;
+    };
+
+    return (
+      <View
+        style={styles.wrapperStyle}
+        ref={wrapperRef}
+        pointerEvents="box-none"
+        onLayout={onLayout}
+      >
+        <TouchableWithoutFeedback onPress={focus} hitSlop={8}>
+          <Animated.View
+            style={[
+              isFocused ? styles.inputRowFocused : styles.inputRow,
+              style,
+              wrapperStyle,
+            ]}
+          >
+            <TextInput
+              ref={inputRef}
+              placeholder={placeholder}
+              placeholderTextColor={color.grayMid}
+              value={value}
+              onChangeText={onChange}
+              style={center ? styles.inputCentered : styles.input}
+              multiline={Platform.OS === "android" && center}
+              numberOfLines={1}
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              autoCapitalize="none"
+              autoCorrect={false}
+              spellCheck={false}
+              autoFocus={autoFocus}
+              secureTextEntry={needsAndroidWorkaround}
+              keyboardType={
+                needsAndroidWorkaround ? "visible-password" : "default"
+              }
+              onFocus={onInputFocus}
+              onBlur={onInputBlur}
+              selectTextOnFocus
+            />
+            {icon && (
+              <Animated.View style={styles.inputIcon}>
+                <Octicons name={icon} size={18} color={color.primary} />
+              </Animated.View>
+            )}
+          </Animated.View>
+        </TouchableWithoutFeedback>
+      </View>
+    );
+  }
+);
 
 const inputRow = {
   height: 48,

--- a/apps/daimo-mobile/src/view/shared/SearchHeader.tsx
+++ b/apps/daimo-mobile/src/view/shared/SearchHeader.tsx
@@ -1,5 +1,5 @@
 import Octicons from "@expo/vector-icons/Octicons";
-import { RefObject, useCallback, useEffect } from "react";
+import { RefObject, useCallback, useEffect, useRef } from "react";
 import { Keyboard, StyleSheet, TextInput, View } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import Animated, {
@@ -8,7 +8,10 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-import { AnimatedSearchInput } from "./AnimatedSearchInput";
+import {
+  AnimatedSearchInput,
+  AnimatedSearchInputRef,
+} from "./AnimatedSearchInput";
 import { ButtonCircle } from "./ButtonCircle";
 import { ContactBubble } from "./ContactBubble";
 import { color } from "./style";
@@ -30,6 +33,7 @@ export function SearchHeader({
 }) {
   const isFocused = useSharedValue(prefix != null);
   const nav = useNav();
+  const ref = useRef<AnimatedSearchInputRef>(null);
 
   useEffect(() => {
     isFocused.value = prefix != null;
@@ -89,7 +93,14 @@ export function SearchHeader({
   return (
     <View style={styles.header}>
       <Animated.View key="back" style={backButton}>
-        <TouchableOpacity onPress={() => Keyboard.dismiss()} hitSlop={16}>
+        <TouchableOpacity
+          onPress={() => {
+            setPrefix(undefined);
+            Keyboard.dismiss();
+            ref.current?.closeInput();
+          }}
+          hitSlop={16}
+        >
           <Octicons name="arrow-left" size={30} color={color.midnight} />
         </TouchableOpacity>
       </Animated.View>
@@ -99,12 +110,13 @@ export function SearchHeader({
         </ButtonCircle>
       </Animated.View>
       <AnimatedSearchInput
+        ref={ref}
         icon="search"
         placeholder="Search for user..."
         value={prefix || ""}
         onChange={setPrefix}
-        onFocus={() => setPrefix("")}
-        onBlur={() => setPrefix(undefined)}
+        onFocus={() => setPrefix(prefix || "")}
+        onClose={() => setPrefix(undefined)}
         innerRef={innerRef}
         style={{ zIndex: 10 }}
       />


### PR DESCRIPTION
Closes #829

The reason why thing in the video happens is that sometimes it's possible to accidentally close the keyboard and it results in closing whole search list.

This PR makes it so it only do so if the input is empty or the back arrow is pressed.
On refocus it clears the input right now but it can be easily changed.

Also the keybaord padding can be animated using useAnimatedKeyboard but wanted to let this PR be simpler and change it in future PR if necessary

iOS:

https://github.com/daimo-eth/daimo/assets/42337257/107ca88b-2d11-4a04-b04b-0e25f3da7d94

