### PR TITLE
trpc: correct context

### DIFF
--- a/apps/daimo-mobile/src/logic/trpc.tsx
+++ b/apps/daimo-mobile/src/logic/trpc.tsx
@@ -20,7 +20,7 @@ const apiUrlMainnetWithChain = `${apiUrlM}/chain/8453`;
 function createRpcHook() {
   const reactQueryContext = createContext<QueryClient | undefined>(undefined);
   return {
-    trpc: createTRPCReact<AppRouter>({}),
+    trpc: createTRPCReact<AppRouter>({ context: reactQueryContext }),
     reactQueryContext,
     queryClient: new QueryClient({
       defaultOptions: {


### PR DESCRIPTION
Went very deep into the TRPC codebase and it turns out they do actually still need this -- only tanstack upstream has removed it, they haven't.