### PR TITLE
Fix delay in updating profile pictures after invites

### DIFF
--- a/apps/daimo-web/src/app/profile/[...addr]/route.tsx
+++ b/apps/daimo-web/src/app/profile/[...addr]/route.tsx
@@ -27,6 +27,7 @@ export async function GET(_: Request, { params }: Context) {
     }
 
     if (result == null) {
+      console.warn(`[PROFILE] No image found for ${addr}`);
       return NextResponse.json({ error: "No image found" }, { status: 404 });
     }
 


### PR DESCRIPTION
This PR fixes an issue where FC profile pictures did not appear on account screens for a while after they were already visible on other screens (particularly the Invite screen). They only became visible on subsequent screen loads.

## Reproduction of the causal bug

Main:
- Invite a user and have them create an account
- Open their account screen
- Go back to the invite screen
- Have them link their FC account
- Navigate to the account screen again (the profile picture does not appear)

Hack (useful in both dev/prod testing:)
- Unlink an FC account from an invited Daimo account
- Open the invited account's account screen
- Go back to the invite screen
- Re-link the FC account
- Navigate to the account screen again (the profile picture does not appear)

## Solution

This PR sets the `gcTime` property of the `useFetchLinkStatus` query to `0`, ensuring that the account screen's data is fetched from the server on every load. It should be noted that while this technically solves the problem, it slightly degrades the UX of this flow, as loading a previously viewed account will feel noticeably slower.