### PR TITLE
small fixes

### DIFF
--- a/apps/daimo-mobile/src/view/sheet/HelpBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/HelpBottomSheet.tsx
@@ -22,11 +22,11 @@ export function HelpBottomSheet({
       <TextCenter>
         <TextH3>{title}</TextH3>
       </TextCenter>
-      <Spacer h={12} />
+      <Spacer h={24} />
       {content}
       <Spacer h={32} />
       <ButtonMed title="GOT IT" onPress={onPress} type="subtle" />
-      <Spacer h={24} />
+      <Spacer h={48} />
     </View>
   );
 }

--- a/apps/scratchpad/package.json
+++ b/apps/scratchpad/package.json
@@ -3,7 +3,8 @@
   "name": "scratchpad",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@daimo/api": "*",

--- a/apps/scratchpad/src/index.ts
+++ b/apps/scratchpad/src/index.ts
@@ -7,6 +7,7 @@ import { RequestIndexer } from "@daimo/api/src/contract/requestIndexer";
 import { DB } from "@daimo/api/src/db/db";
 import { getViemClientFromEnv } from "@daimo/api/src/network/viemClient";
 import { InviteGraph } from "@daimo/api/src/offchain/inviteGraph";
+import { PaymentMemoTracker } from "@daimo/api/src/offchain/paymentMemoTracker";
 import { Telemetry } from "@daimo/api/src/server/telemetry";
 import { guessTimestampFromNum } from "@daimo/common";
 import { daimoChainFromId, nameRegistryProxyConfig } from "@daimo/contract";
@@ -71,11 +72,13 @@ async function metrics() {
   const opIndexer = new OpIndexer();
   const noteIndexer = new NoteIndexer(nameReg);
   const requestIndexer = new RequestIndexer(nameReg);
+  const paymentMemoTracker = new PaymentMemoTracker(db);
   const coinIndexer = new CoinIndexer(
     vc,
     opIndexer,
     noteIndexer,
-    requestIndexer
+    requestIndexer,
+    paymentMemoTracker
   );
 
   console.log(`[METRICS] using ${vc.publicClient.chain.name}`);

--- a/packages/daimo-api/test/dtest.ts
+++ b/packages/daimo-api/test/dtest.ts
@@ -34,11 +34,8 @@ async function main() {
   const shovelWatcher = new Watcher();
   shovelWatcher.add(keyReg, nameReg, opIndexer, coinIndexer, noteIndexer);
 
-  const { startBlock, lastBlockNum } = {
-    startBlock: 5700000,
-    lastBlockNum: 7000000,
-  };
-  await shovelWatcher.indexRange(startBlock, lastBlockNum);
+  const lastBlockNum = 7000000;
+  await shovelWatcher.catchUpTo(lastBlockNum);
 
   let numKeyData: number = 0;
   keyReg["addrToKeyData"].forEach((addr, kd) => (numKeyData += kd.length));


### PR DESCRIPTION
### api: fix tip-1 error, faster startup

The current ShovelWatcher loads 2 blocks at a time!
```
[SHOVEL] loaded 12456222 to 12456223 in 14ms
[...]
[SHOVEL] loaded 12456224 to 12456225 in 23ms
```

This PR fixes that, and also speeds up API server startup significantly. (Now that we are filtering transfers and ops + using retryBackoff, we can go back to using a 100k-block batch size.)

Users should see transfers confirm 1s faster on average and 2s faster worst-case due to this fix.


### fix Use Existing after logout

fixes #860 

### better HelpModal

<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/4f3c1012-406d-4755-a338-f93ce88d8dd0">
