### PR TITLE
mobile: onboarding, bottom sheet fixes

### DIFF
--- a/apps/daimo-mobile/src/App.tsx
+++ b/apps/daimo-mobile/src/App.tsx
@@ -1,39 +1,21 @@
 import { now } from "@daimo/common";
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetView,
-} from "@gorhom/bottom-sheet";
-import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types";
 import { DefaultTheme, NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import {
-  ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useMemo } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { Keyboard, StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import RNShake from "react-native-shake";
 
-import { Action, Dispatcher, DispatcherContext } from "./action/dispatch";
+import { Dispatcher, DispatcherContext } from "./action/dispatch";
 import { useAccount } from "./logic/accountManager";
 import { useInitNotifications } from "./logic/notify";
 import { RpcProvider } from "./logic/trpc";
 import { TabNav } from "./view/TabNav";
 import { renderErrorFallback } from "./view/screen/errorScreens";
-import ScrollPellet from "./view/shared/ScrollPellet";
 import { color } from "./view/shared/style";
-import { DebugBottomSheet } from "./view/sheet/DebugBottomSheet";
-import { FarcasterBottomSheet } from "./view/sheet/FarcasterBottomSheet";
-import { HelpBottomSheet } from "./view/sheet/HelpBottomSheet";
-import { OnboardingChecklistBottomSheet } from "./view/sheet/OnboardingChecklistBottomSheet";
+import { GlobalBottomSheet } from "./view/sheet/GlobalBottomSheet";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -52,181 +34,36 @@ export default function App() {
   let theme = DefaultTheme;
   theme = { ...theme, colors: { ...theme.colors, background: color.white } };
 
+  // Remove splash screen
   useEffect(() => {
     const nowS = now();
     if (account == null || nowS - account.lastBlockTimestamp < 60 * 10) {
+      console.log(`[APP] removing splash now, first render`);
       SplashScreen.hideAsync();
+    } else {
+      console.log(`[APP] removing splash after sync or 2s, whichever is first`);
+      setTimeout(() => SplashScreen.hideAsync(), 2000);
     }
   }, []);
+
+  // Global dispatcher
+  const dispatcher = useMemo(() => new Dispatcher(), []);
 
   return (
     <RpcProvider>
       <GestureHandlerRootView style={{ flex: 1 }}>
         <NavigationContainer theme={theme}>
-          <AppBody />
+          <DispatcherContext.Provider value={dispatcher}>
+            <ErrorBoundary fallbackRender={renderErrorFallback}>
+              <SafeAreaProvider>
+                <TabNav />
+                <StatusBar style="auto" />
+                <GlobalBottomSheet />
+              </SafeAreaProvider>
+            </ErrorBoundary>
+          </DispatcherContext.Provider>
         </NavigationContainer>
       </GestureHandlerRootView>
     </RpcProvider>
   );
 }
-
-const bottomSheetSettings = {
-  debug: {
-    snapPoints: ["33%"],
-    enableSwipeClose: true,
-  },
-  connectFarcaster: {
-    snapPoints: ["66%"],
-    enableSwipeClose: true,
-  },
-  linkFarcaster: {
-    snapPoints: ["66%"],
-    enableSwipeClose: false,
-  },
-  onboardingChecklist: {
-    snapPoints: ["50%"],
-    enableSwipeClose: true,
-  },
-  helpModal: {
-    snapPoints: [],
-    enableSwipeClose: true,
-  },
-} as const;
-const defaultSnapPoints = ["10%"];
-
-type GlobalBottomSheet = null | {
-  action: keyof typeof bottomSheetSettings;
-  payload?: { title: string; content: ReactElement };
-};
-
-function AppBody() {
-  // Global dispatcher
-  const dispatcher = useMemo(() => new Dispatcher(), []);
-
-  // Global bottom sheet
-  const bottomSheetRef = useRef<BottomSheet>(null);
-  const [bottomSheet, setBottomSheet] = useState<GlobalBottomSheet>(null);
-
-  const settings = bottomSheet && bottomSheetSettings[bottomSheet?.action];
-  const snapPoints = settings?.snapPoints || defaultSnapPoints;
-  const enableSwipeClose = settings?.enableSwipeClose || false;
-
-  const openBottomSheet = (sheet: GlobalBottomSheet) => {
-    Keyboard.dismiss();
-    setBottomSheet(sheet);
-  };
-
-  // Global shake gesture > open Send Debug Log sheet
-  useEffect(() => {
-    const subscription = RNShake.addListener(() =>
-      openBottomSheet({ action: "debug" })
-    );
-    return () => subscription.remove();
-  }, []);
-
-  // Open bottom sheet when requested
-  useEffect(() => {
-    console.log(`[APP] bottomSheet=${bottomSheet}`);
-    if (bottomSheet) bottomSheetRef.current?.expand();
-    else bottomSheetRef.current?.close();
-  }, [bottomSheet]);
-
-  // Close bottom sheet when user swipes it away
-  const onChangeIndex = useCallback((index: number) => {
-    if (index < 0) setBottomSheet(null);
-  }, []);
-
-  const onClose = useCallback(() => {
-    setBottomSheet(null);
-  }, []);
-
-  // Dark backdrop for bottom sheet
-  const renderBackdrop = useCallback(
-    (props: BottomSheetDefaultBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        disappearsOnIndex={-0.9}
-        appearsOnIndex={0}
-        pressBehavior="close"
-      />
-    ),
-    []
-  );
-
-  // Handle dispatch > open bottom sheet
-  const openFC = () => openBottomSheet({ action: "connectFarcaster" });
-  const linkFC = () => openBottomSheet({ action: "linkFarcaster" });
-  const openChecklist = () =>
-    openBottomSheet({ action: "onboardingChecklist" });
-  useEffect(() => dispatcher.register("connectFarcaster", openFC), []);
-  useEffect(() => dispatcher.register("linkFarcaster", linkFC), []);
-  useEffect(
-    () => dispatcher.register("onboardingChecklist", openChecklist),
-    []
-  );
-
-  //  Handle dispatch > hide bottom sheet
-  const hideSheet = () => setBottomSheet(null);
-  useEffect(() => dispatcher.register("hideBottomSheet", hideSheet), []);
-
-  const openHelp = (actionPayload: Action) => {
-    if (actionPayload.name === "helpModal") {
-      setBottomSheet({ action: "helpModal", payload: actionPayload });
-    }
-  };
-  useEffect(() => dispatcher.register("helpModal", openHelp), []);
-
-  return (
-    <DispatcherContext.Provider value={dispatcher}>
-      <ErrorBoundary fallbackRender={renderErrorFallback}>
-        <SafeAreaProvider>
-          <TabNav />
-          <StatusBar style="auto" />
-          <View
-            style={styles.bottomSheetWrapper}
-            pointerEvents={bottomSheet != null ? "auto" : "none"}
-          >
-            <BottomSheet
-              handleComponent={ScrollPellet}
-              backdropComponent={renderBackdrop}
-              ref={bottomSheetRef}
-              index={-1}
-              snapPoints={snapPoints}
-              onChange={onChangeIndex}
-              onClose={onClose}
-              enablePanDownToClose={enableSwipeClose}
-              enableDynamicSizing={bottomSheet?.action === "helpModal"}
-            >
-              {bottomSheet?.action === "debug" && <DebugBottomSheet />}
-              {(bottomSheet?.action === "connectFarcaster" ||
-                bottomSheet?.action === "linkFarcaster") && (
-                <FarcasterBottomSheet />
-              )}
-              {bottomSheet?.action === "onboardingChecklist" && (
-                <OnboardingChecklistBottomSheet />
-              )}
-              {bottomSheet?.action === "helpModal" && bottomSheet?.payload && (
-                <BottomSheetView>
-                  <HelpBottomSheet
-                    content={bottomSheet.payload.content}
-                    title={bottomSheet.payload.title}
-                    onPress={() => bottomSheetRef.current?.close()}
-                  />
-                </BottomSheetView>
-              )}
-            </BottomSheet>
-          </View>
-        </SafeAreaProvider>
-      </ErrorBoundary>
-    </DispatcherContext.Provider>
-  );
-}
-
-const styles = StyleSheet.create({
-  bottomSheetWrapper: {
-    position: "absolute",
-    height: "100%",
-    width: "100%",
-    alignItems: "center",
-  },
-});

--- a/apps/daimo-mobile/src/view/shared/Button.tsx
+++ b/apps/daimo-mobile/src/view/shared/Button.tsx
@@ -160,7 +160,7 @@ export function TextButton(props: TextButtonProps) {
 // Shows the (?) icon. Should open the help modal.
 export function HelpButton({ onPress }: { onPress: () => void }) {
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity onPress={onPress} hitSlop={16}>
       <Octicons size={16} name="info" color={color.grayDark} />
     </TouchableOpacity>
   );

--- a/apps/daimo-mobile/src/view/shared/style.ts
+++ b/apps/daimo-mobile/src/view/shared/style.ts
@@ -62,6 +62,9 @@ export const ss = {
     padH16: {
       paddingHorizontal: 16,
     },
+    padH24: {
+      paddingHorizontal: 24,
+    },
     marginHNeg16: {
       marginHorizontal: -16,
     },

--- a/apps/daimo-mobile/src/view/sheet/DebugBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/DebugBottomSheet.tsx
@@ -8,15 +8,14 @@ import { TextH3, TextLight } from "../shared/text";
 // Global shake gesture > "Send Debug Log" sheet
 export function DebugBottomSheet() {
   return (
-    <View style={ss.container.screen}>
-      <View style={ss.container.padH16}>
-        <Spacer h={16} />
-        <TextH3>Did something go wrong?</TextH3>
-        <Spacer h={12} />
-        <TextLight>Help us realize what's going wrong.</TextLight>
-        <Spacer h={32} />
-        <SendDebugLogButton />
-      </View>
+    <View style={ss.container.padH16}>
+      <Spacer h={16} />
+      <TextH3>Did something go wrong?</TextH3>
+      <Spacer h={12} />
+      <TextLight>Help us realize what's going wrong.</TextLight>
+      <Spacer h={32} />
+      <SendDebugLogButton />
+      <Spacer h={48} />
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx
@@ -77,17 +77,16 @@ function FarcasterBottomSheetInner({ account }: { account: Account }) {
     else if (fcAccount != null) return "Your account is linked";
     else return "Connect Farcaster";
   })();
+
   return (
-    <View style={ss.container.screen}>
-      <View style={ss.container.padH16}>
-        <Spacer h={16} />
-        <TextH3>{header}</TextH3>
-        <Spacer h={12} />
-        {isLoading && url == null && <TextLight>Loading...</TextLight>}
-        {isLoading && url != null && <FarcasterQRButton url={url} />}
-        {hasFcAccount && <LinkFarcasterSection {...{ account, data }} />}
-        {error && <ErrorRowCentered error={error} />}
-      </View>
+    <View style={{ ...ss.container.padH16, height: 472 }}>
+      <Spacer h={16} />
+      <TextH3>{header}</TextH3>
+      <Spacer h={12} />
+      {isLoading && url == null && <TextLight>Loading...</TextLight>}
+      {isLoading && url != null && <FarcasterQRButton url={url} />}
+      {hasFcAccount && <LinkFarcasterSection {...{ account, data }} />}
+      {error && <ErrorRowCentered error={error} />}
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/sheet/GlobalBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/GlobalBottomSheet.tsx
@@ -1,0 +1,169 @@
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetView,
+} from "@gorhom/bottom-sheet";
+import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types";
+import {
+  ReactElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Keyboard, StyleSheet, View } from "react-native";
+import RNShake from "react-native-shake";
+
+import { DebugBottomSheet } from "./DebugBottomSheet";
+import { FarcasterBottomSheet } from "./FarcasterBottomSheet";
+import { HelpBottomSheet } from "./HelpBottomSheet";
+import { OnboardingChecklistBottomSheet } from "./OnboardingChecklistBottomSheet";
+import { Action, DispatcherContext } from "../../action/dispatch";
+import ScrollPellet from "../shared/ScrollPellet";
+
+const bottomSheetSettings = {
+  debug: {
+    enableSwipeClose: true,
+  },
+  connectFarcaster: {
+    enableSwipeClose: true,
+  },
+  linkFarcaster: {
+    enableSwipeClose: false,
+  },
+  onboardingChecklist: {
+    enableSwipeClose: true,
+  },
+  helpModal: {
+    enableSwipeClose: true,
+  },
+} as const;
+
+type DisplayedSheet = null | {
+  action: keyof typeof bottomSheetSettings;
+  payload?: { title: string; content: ReactElement };
+};
+
+// Shows the main, global bottom sheet. This ensures that only a single of
+// these sheets is visible at a time. The global sheet appears above any screen
+// -specific sheets like the transaction detail sheet.
+export function GlobalBottomSheet() {
+  // Global bottom sheet
+  const sheetRef = useRef<BottomSheet>(null);
+  const [sheet, setSheet] = useState<DisplayedSheet>(null);
+
+  const openBottomSheet = (sheet: DisplayedSheet) => {
+    Keyboard.dismiss();
+    setSheet(sheet);
+  };
+
+  // Global shake gesture > open Send Debug Log sheet
+  useEffect(() => {
+    const subscription = RNShake.addListener(() =>
+      openBottomSheet({ action: "debug" })
+    );
+    return () => subscription.remove();
+  }, []);
+
+  // Open bottom sheet when requested
+  useEffect(() => {
+    console.log(`[APP] new bottomSheet=${sheet?.action}`);
+    if (sheet) sheetRef.current?.expand();
+    else sheetRef.current?.close();
+  }, [sheet]);
+
+  // Close bottom sheet when user swipes it away
+  const onChangeIndex = useCallback((index: number) => {
+    if (index < 0) setSheet(null);
+  }, []);
+
+  const onClose = useCallback(() => {
+    setSheet(null);
+  }, []);
+
+  // Dark backdrop for bottom sheet
+  const renderBackdrop = useCallback(
+    (props: BottomSheetDefaultBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-0.9}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
+  // Handle dispatch > open bottom sheet
+  const dispatcher = useContext(DispatcherContext);
+  const openFC = () => openBottomSheet({ action: "connectFarcaster" });
+  const linkFC = () => openBottomSheet({ action: "linkFarcaster" });
+  const openChecklist = () =>
+    openBottomSheet({ action: "onboardingChecklist" });
+  useEffect(() => dispatcher.register("connectFarcaster", openFC), []);
+  useEffect(() => dispatcher.register("linkFarcaster", linkFC), []);
+  useEffect(
+    () => dispatcher.register("onboardingChecklist", openChecklist),
+    []
+  );
+
+  //  Handle dispatch > hide bottom sheet
+  const hideSheet = () => setSheet(null);
+  useEffect(() => dispatcher.register("hideBottomSheet", hideSheet), []);
+
+  const openHelp = (actionPayload: Action) => {
+    if (actionPayload.name === "helpModal") {
+      setSheet({ action: "helpModal", payload: actionPayload });
+    }
+  };
+  useEffect(() => dispatcher.register("helpModal", openHelp), []);
+
+  // Hide if there's no sheet
+  console.log(`[APP] rendering bottomSheet=${sheet?.action}`);
+
+  const settings = sheet && bottomSheetSettings[sheet.action];
+
+  return (
+    <View
+      style={styles.bottomSheetWrapper}
+      pointerEvents={sheet != null ? "auto" : "none"}
+    >
+      <BottomSheet
+        handleComponent={ScrollPellet}
+        backdropComponent={renderBackdrop}
+        ref={sheetRef}
+        snapPoints={[]}
+        index={-1}
+        onChange={onChangeIndex}
+        onClose={onClose}
+        enablePanDownToClose={settings?.enableSwipeClose}
+        enableDynamicSizing
+      >
+        <BottomSheetView style={{ flex: 0, minHeight: 100 }}>
+          {sheet?.action === "debug" && <DebugBottomSheet />}
+          {(sheet?.action === "connectFarcaster" ||
+            sheet?.action === "linkFarcaster") && <FarcasterBottomSheet />}
+          {sheet?.action === "onboardingChecklist" && (
+            <OnboardingChecklistBottomSheet />
+          )}
+          {sheet?.action === "helpModal" && sheet?.payload && (
+            <HelpBottomSheet
+              content={sheet.payload.content}
+              title={sheet.payload.title}
+              onPress={() => sheetRef.current?.close()}
+            />
+          )}
+        </BottomSheetView>
+      </BottomSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bottomSheetWrapper: {
+    position: "absolute",
+    height: "100%",
+    width: "100%",
+    alignItems: "center",
+  },
+});

--- a/apps/daimo-mobile/src/view/sheet/OnboardingChecklistBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/OnboardingChecklistBottomSheet.tsx
@@ -4,9 +4,9 @@ import { StyleSheet, View } from "react-native";
 
 import { useOnboardingChecklist } from "../../logic/onboarding";
 import { Account } from "../../model/account";
-import { ButtonBig } from "../shared/Button";
+import { TextButton } from "../shared/Button";
 import Spacer from "../shared/Spacer";
-import { color, touchHighlightUnderlay } from "../shared/style";
+import { color, ss, touchHighlightUnderlay } from "../shared/style";
 import { DaimoText, TextBody, TextH3 } from "../shared/text";
 import { useWithAccount } from "../shared/withAccount";
 
@@ -25,7 +25,7 @@ function OnboardingChecklistBottomSheetInner({
     farcasterConnected,
     handleSecureAccount,
     handleConnectFarcaster,
-    dismissSheet,
+    dismissChecklist,
   } = useOnboardingChecklist(account);
 
   return (
@@ -51,14 +51,13 @@ function OnboardingChecklistBottomSheetInner({
         onPress={handleConnectFarcaster}
         done={farcasterConnected}
       />
-      <Spacer h={24} />
-      <View style={{ paddingHorizontal: 24 }}>
-        <ButtonBig
-          type="subtle"
-          title={`I'll get to it later`}
-          onPress={dismissSheet}
-        />
+      <Spacer h={16} />
+      <View style={ss.container.padH24}>
+        {dismissChecklist && (
+          <TextButton title="DISMISS" onPress={dismissChecklist} />
+        )}
       </View>
+      <Spacer h={48} />
     </View>
   );
 }

--- a/apps/daimo-mobile/src/view/sheet/OnboardingChecklistBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/OnboardingChecklistBottomSheet.tsx
@@ -47,7 +47,7 @@ function OnboardingChecklistBottomSheetInner({
       <ChecklistRow
         step={2}
         title="Connect Farcaster"
-        description="Import your profile image and connections"
+        description="Import profile picture and connections"
         onPress={handleConnectFarcaster}
         done={farcasterConnected}
       />


### PR DESCRIPTION
## Dynamically size the global bottom sheet

This puts the button always in the same spot, and gracefully handles smaller phones.

<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/077177e8-79f5-43b2-8c6a-d31938b9704b">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/40630888-118f-4e68-8dce-d356a98bdf18">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/6e988b63-f0bf-41b8-a946-b39de23cc4f0">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/f79d7170-fd43-4081-b34d-cb4f91243b1c">


## Onboarding checklist dismissable once you've added a backup
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/4173deb2-24e9-4cd6-9635-57e27cd4e47e">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/47840e28-a5bc-4f10-9f82-06e738d5e50c">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/46ec173d-05f1-44fb-8392-54c54b89441d">
<img width="250" alt="image" src="https://github.com/daimo-eth/daimo/assets/169280/c6422f45-4c06-4b57-968f-151ab3cc910d">



