### PR TITLE
release: 1.8.0

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.8.0";
+const VERSION = "1.8.1";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
**Memos, in-app requests, onboarding checklist.**

## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly
- [x] Logs look clean.

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account
- [x] Faucet + notification should appear automatically.
- [x] Send payment
- [x] Create Payment Link, open in browser
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Create Request, open in browser
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account. Found https://github.com/daimo-eth/daimo/issues/964 , likely system issue, fixed on restart.
- [x] Faucet + notification should appear automatically. **"Finish setting up your account" button shadow looks odd. Not a release blocker.**
- [x] Send payment
- [x] Create Payment Link. 
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app. **Tap works. Opening testnet (=missing) payment link on prod daimo.com shows 500 now. Not a release blocker as long as doesn't happen with actual (=present) payment links, but should fix to show graceful error page again.**
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device
- [x] Create Request
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### macOS

Smoke test, particularly for visual regressions:

- [x] Install from Testflight
- [x] Send payment
- [x] Share invite link
- [x] Delete account and restore from passkey backup

### Push to prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean
- [x] Honeycomb clean.  **Mostly. [A few look like flakiness in LlamaRpc](https://ui.honeycomb.io/daimo/environments/prod/datasets/daimo-api/result/9UZ4QF7Xj7T?tab=events)**

### Prod smoke test

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
