### PR TITLE
`npm install` improvements

### DIFF
--- a/apps/daimo-mobile/tsconfig.json
+++ b/apps/daimo-mobile/tsconfig.json
@@ -3,5 +3,14 @@
   "compilerOptions": {
     "strict": true
   },
-  "include": ["./*.js", "./src/**/*", "./test/**/*", "app.config.ts"]
+  "include": ["./*.js", "./src/**/*", "./test/**/*", "app.config.ts"],
+  "references": [
+    { "path": "../../packages/daimo-api" },
+    { "path": "../../packages/daimo-common" },
+    { "path": "../../packages/daimo-userop" },
+    { "path": "../../packages/daimo-contract" },
+    { "path": "../../packages/daimo-expo-enclave" },
+    { "path": "../../packages/daimo-expo-passkeys" },
+    { "path": "../../packages/daimo-expo-app-delegate" }
+  ]
 }

--- a/packages/daimo-api/package.json
+++ b/packages/daimo-api/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "license": "GPL-3.0-or-later",
   "description": "Daimo API for account creation, search, etc",
-  "main": "src/index.ts",
+  "main": "dist/src/index.js",
   "scripts": {
+    "build": "tsc",
     "dev": "OTEL_SERVICE_NAME=daimo-api ts-node-dev -r ./src/server/tracing.ts src/server/server.ts",
     "start": "OTEL_SERVICE_NAME=daimo-api node --max-old-space-size=7168 -- ../../node_modules/.bin/ts-node -r ./src/server/tracing.ts src/server/server.ts",
     "test": "tsc --noEmit && DAIMO_DOMAIN=example.com tape -r ts-node/register/transpile-only test/**/*.test.ts",

--- a/packages/daimo-api/src/api/validateMemo.ts
+++ b/packages/daimo-api/src/api/validateMemo.ts
@@ -9,7 +9,7 @@ const obscenityConfig = new RegExpMatcher({
   ...englishRecommendedTransformers,
 });
 
-enum MemoStatus {
+export enum MemoStatus {
   OK = "ok",
   TOO_LONG = "too long",
   VIOLATES_GUIDELINES = "violates guidelines",

--- a/packages/daimo-api/tsconfig.json
+++ b/packages/daimo-api/tsconfig.json
@@ -6,7 +6,13 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../daimo-common" },
+    { "path": "../daimo-contract" },
+    { "path": "../daimo-userop" }
+  ]
 }

--- a/packages/daimo-api/tsconfig.json
+++ b/packages/daimo-api/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "strict": true,
-    "resolveJsonModule": true
-  }
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/packages/daimo-common/package.json
+++ b/packages/daimo-common/package.json
@@ -2,8 +2,8 @@
   "name": "@daimo/common",
   "version": "0.1.0",
   "description": "Shared between web and mobile",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "DAIMO_DOMAIN=example.com tape -r ts-node/register/transpile-only test/**/*.test.ts",

--- a/packages/daimo-common/tsconfig.json
+++ b/packages/daimo-common/tsconfig.json
@@ -6,7 +6,11 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../daimo-contract" }
+  ]
 }

--- a/packages/daimo-contract/package.json
+++ b/packages/daimo-contract/package.json
@@ -2,8 +2,8 @@
   "name": "@daimo/contract",
   "version": "0.1.0",
   "description": "Daimo contracts, ABIs, and generated Typescript types",
-  "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
+  "types": "./dist/src/index.d.ts",
+  "main": "./dist/src/index.js",
   "scripts": {
     "codegen": "wagmi -v && wagmi generate",
     "build": "tsc"

--- a/packages/daimo-contract/tsconfig.json
+++ b/packages/daimo-contract/tsconfig.json
@@ -5,8 +5,9 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "composite": true
   },
-  "include": ["src/index.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": []
 }

--- a/packages/daimo-expo-app-delegate/tsconfig.json
+++ b/packages/daimo-expo-app-delegate/tsconfig.json
@@ -2,7 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "composite": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]

--- a/packages/daimo-expo-enclave/tsconfig.json
+++ b/packages/daimo-expo-enclave/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./build",
     "lib": ["es2015"],
-    "types": null
+    "types": null,
+    "composite": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]

--- a/packages/daimo-expo-passkeys/tsconfig.json
+++ b/packages/daimo-expo-passkeys/tsconfig.json
@@ -2,7 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "composite": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]

--- a/packages/daimo-userop/package.json
+++ b/packages/daimo-userop/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "license": "GPL-3.0-or-later",
   "description": "userop.js for daimo account contracts",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "tape -r ts-node/register/transpile-only test/**/*.test.ts",

--- a/packages/daimo-userop/tsconfig.json
+++ b/packages/daimo-userop/tsconfig.json
@@ -6,7 +6,12 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../daimo-common" },
+    { "path": "../daimo-contract" }
+  ]
 }


### PR DESCRIPTION
`npm install` doesn't automatically run `build` scripts, but it [does](https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-install) run `prepare` scripts.

Not sure how you were previously handling this (maybe `eas` has some special handling?), but this change should compile all of the `@daimo/*` packages when running `npm install` in the repo.

I've also updated `@daimo/api` to use the same tsconfig as the other packages (uncovering a type bug in the process!).