### PR TITLE
feat: Add get memo api endpoint

### DIFF
--- a/packages/daimo-api/src/api/getMemo.ts
+++ b/packages/daimo-api/src/api/getMemo.ts
@@ -3,18 +3,31 @@ import { Hex } from "viem";
 import { OpIndexer, UserOp } from "../contract/opIndexer";
 import { PaymentMemoTracker } from "../offchain/paymentMemoTracker";
 
+type TransactionMemo = {
+  txHash: Hex;
+  logIndex: number;
+  opHash?: Hex;
+  memo?: string;
+};
+
 /** Retreives a payment memo given a transaction hash and log index. */
 export async function getMemo(
   txHash: string,
   logIndex: number,
   opIndexer: OpIndexer,
   paymentMemoTracker: PaymentMemoTracker
-): Promise<string | undefined> {
+): Promise<TransactionMemo | undefined> {
   const userOp: UserOp | undefined = opIndexer.fetchUserOpLog(
     txHash as Hex,
     logIndex
   );
   const opHash = userOp?.hash;
   const memo = opHash ? paymentMemoTracker.getMemo(opHash) : undefined;
-  return memo;
+  const transactionMemo: TransactionMemo = {
+    txHash: txHash as Hex,
+    logIndex,
+    opHash,
+    memo,
+  };
+  return transactionMemo;
 }

--- a/packages/daimo-api/src/api/getMemo.ts
+++ b/packages/daimo-api/src/api/getMemo.ts
@@ -1,0 +1,20 @@
+import { Hex } from "viem";
+
+import { OpIndexer, UserOp } from "../contract/opIndexer";
+import { PaymentMemoTracker } from "../offchain/paymentMemoTracker";
+
+/** Retreives a payment memo given a transaction hash and log index. */
+export async function getMemo(
+  txHash: string,
+  logIndex: number,
+  opIndexer: OpIndexer,
+  paymentMemoTracker: PaymentMemoTracker
+): Promise<string | undefined> {
+  const userOp: UserOp | undefined = opIndexer.fetchUserOpLog(
+    txHash as Hex,
+    logIndex
+  );
+  const opHash = userOp?.hash;
+  const memo = opHash ? paymentMemoTracker.getMemo(opHash) : undefined;
+  return memo;
+}

--- a/packages/daimo-api/src/api/getMemo.ts
+++ b/packages/daimo-api/src/api/getMemo.ts
@@ -17,10 +17,7 @@ export async function getMemo(
   opIndexer: OpIndexer,
   paymentMemoTracker: PaymentMemoTracker
 ): Promise<TransactionMemo | undefined> {
-  const userOp: UserOp | undefined = opIndexer.fetchUserOpLog(
-    txHash as Hex,
-    logIndex
-  );
+  const userOp: UserOp | undefined = opIndexer.fetchUserOpLog(txHash, logIndex);
   const opHash = userOp?.hash;
   const memo = opHash ? paymentMemoTracker.getMemo(opHash) : undefined;
   const transactionMemo: TransactionMemo = {

--- a/packages/daimo-api/src/api/getMemo.ts
+++ b/packages/daimo-api/src/api/getMemo.ts
@@ -12,7 +12,7 @@ type TransactionMemo = {
 
 /** Retreives a payment memo given a transaction hash and log index. */
 export async function getMemo(
-  txHash: string,
+  txHash: Hex,
   logIndex: number,
   opIndexer: OpIndexer,
   paymentMemoTracker: PaymentMemoTracker
@@ -24,7 +24,7 @@ export async function getMemo(
   const opHash = userOp?.hash;
   const memo = opHash ? paymentMemoTracker.getMemo(opHash) : undefined;
   const transactionMemo: TransactionMemo = {
-    txHash: txHash as Hex,
+    txHash,
     logIndex,
     opHash,
     memo,

--- a/packages/daimo-api/src/contract/opIndexer.ts
+++ b/packages/daimo-api/src/contract/opIndexer.ts
@@ -5,7 +5,7 @@ import { Hex, bytesToHex, numberToHex } from "viem";
 import { chainConfig } from "../env";
 import { retryBackoff } from "../utils/retryBackoff";
 
-interface UserOp {
+export interface UserOp {
   transactionHash: Hex;
   logIndex: number;
   nonce: bigint;

--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -332,7 +332,7 @@ export function createRouter(
 
     // Get memo from a transaction hash and log index.
     getMemo: publicProcedure
-      .input(z.object({ txHash: z.string(), logIndex: z.number() }))
+      .input(z.object({ txHash: zHex, logIndex: z.number() }))
       .query(async (opts) => {
         const { txHash, logIndex } = opts.input;
         return getMemo(txHash, logIndex, opIndexer, paymentMemoTracker);

--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -25,6 +25,7 @@ import { createRequestSponsored } from "../api/createRequestSponsored";
 import { deployWallet } from "../api/deployWallet";
 import { getAccountHistory } from "../api/getAccountHistory";
 import { getLinkStatus } from "../api/getLinkStatus";
+import { getMemo } from "../api/getMemo";
 import { ProfileCache } from "../api/profile";
 import { search } from "../api/search";
 import { sendUserOpV2 } from "../api/sendUserOpV2";
@@ -40,6 +41,7 @@ import { CoinIndexer } from "../contract/coinIndexer";
 import { KeyRegistry } from "../contract/keyRegistry";
 import { NameRegistry } from "../contract/nameRegistry";
 import { NoteIndexer } from "../contract/noteIndexer";
+import { OpIndexer } from "../contract/opIndexer";
 import { Paymaster } from "../contract/paymaster";
 import { RequestIndexer } from "../contract/requestIndexer";
 import { DB } from "../db/db";
@@ -61,6 +63,7 @@ export function createRouter(
   bundlerClient: BundlerClient,
   coinIndexer: CoinIndexer,
   noteIndexer: NoteIndexer,
+  opIndexer: OpIndexer,
   reqIndexer: RequestIndexer,
   profileCache: ProfileCache,
   nameReg: NameRegistry,
@@ -325,6 +328,14 @@ export function createRouter(
           inviteGraph
         );
         return { status: "success", address, faucetTransfer };
+      }),
+
+    // Get memo from a transaction hash and log index.
+    getMemo: publicProcedure
+      .input(z.object({ txHash: z.string(), logIndex: z.number() }))
+      .query(async (opts) => {
+        const { txHash, logIndex } = opts.input;
+        return getMemo(txHash, logIndex, opIndexer, paymentMemoTracker);
       }),
 
     // DEPRECATED

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -117,6 +117,7 @@ async function main() {
     bundlerClient,
     coinIndexer,
     noteIndexer,
+    opIndexer,
     requestIndexer,
     profileCache,
     nameReg,


### PR DESCRIPTION
Add a getMemo() api endpoint to retrieve the Daimo payment memo for a given transaction (as defined by its txHash and logIndex). 

Inputs: transaction hash, log index. 
Output: transaction hash, log index, user op, memo. 