### PR TITLE
api: bring back deprected verifyInviteCode endpoint

### DIFF
--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -1,4 +1,5 @@
 import {
+  DaimoLinkInviteCode,
   DaimoLinkRequestV2,
   amountToDollars,
   encodeRequestId,
@@ -531,6 +532,17 @@ export function createRouter(
       .mutation(async (opts) => {
         const { requestId, decliner } = opts.input;
         await reqIndexer.declineRequest(requestId, decliner);
+      }),
+
+    // DEPRECATED
+    verifyInviteCode: publicProcedure
+      .input(z.object({ inviteCode: z.string() }))
+      .query(async (opts) => {
+        const { inviteCode } = opts.input;
+
+        const link: DaimoLinkInviteCode = { type: "invite", code: inviteCode };
+        const status = await inviteCodeTracker.getInviteCodeStatus(link);
+        return status.isValid;
       }),
   });
 }


### PR DESCRIPTION
fix for 
<img width="1136" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/7102d350-40fe-49a6-b0f0-547bfca00729">
