### PR TITLE
release: 1.8.6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 <!-- release v1.2.3 build 101 -->
 <!-- Build number should be identical across both platforms. -->
 
-** Tweet-length summary of changes. **
+**Tweet-length summary of changes.**
 
 <!-- Optional screenshot, 4-6 panels joined as described in scratchpad README. -->
 
@@ -13,7 +13,6 @@
 - [ ] Branch from `master`
 - [ ] Testnet API deployed correctly
 - [ ] Testnet webapp deployed correctly
-- [ ] Logs look clean
 
 ### iOS
 

--- a/apps/daimo-mobile/.maestro/shared/createAccount.yaml
+++ b/apps/daimo-mobile/.maestro/shared/createAccount.yaml
@@ -17,10 +17,11 @@ appId: com.daimo
 - inputText: "maestro"
 - inputRandomNumber:
     length: 8
+- wait: 2
 - assertVisible:
-    text: Create
+    text: CREATE
     enabled: true
-- tapOn: Create
+- tapOn: CREATE
 - assertVisible: Notifications
 - tapOn: Allow Notifications
 - assertVisible: Your balance.*

--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.8.6";
+const VERSION = "1.8.7";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
**Receive any coin, swap to USDC.**

## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly
- [x] Logs look clean

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account. **Subtle border appears on intro video animations, but does *not* appear in screenshots. iOS bug...**
- [x] Faucet + notification should appear automatically.
- [x] Send payment
- [x] Create Payment Link, open in browser. **Testnet payment links don't work in browser. #858**
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Create Request. View in notifications.
- [x] Cancel Request
- [x] Add Device (can add Android, do checklist below)
- [x] Remove device
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Join account (via Add Device, see above)
- [x] Send payment, setting a memo
- [x] Add passkey
- [x] Remove passkey
- [x] Create Request
- [x] Open Notifications, cancel request
- [x] Remove this phone from other device--should show "Missing Key" screen

### Push to prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Honeycomb clean. **500 error when checking getLinkStatus on an invalid payment link. This should return a descriptive error instead.** #1033 

### Prod smoke test

Do this with the Mac app, check for visual regressions.

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly. **Deeplink page displays poorly. This is fixable separately from the release; webapp issue. #1014**
- [x] Tap link. Ensure opens in app, status shows correctly.
- [x] **Receive some ETH.** Should get notification, inbox bubble, show in notifications tab.
- [x] **Swap the ETH in for USDC.**

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
