### PR TITLE
mobile: small UX improvements to deposit address flow

### DIFF
--- a/apps/daimo-mobile/src/view/screen/QRScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/QRScreen.tsx
@@ -2,15 +2,23 @@ import {
   DaimoLinkAccount,
   formatDaimoLink,
   formatDaimoLinkDirect,
-  getAccountName,
+  getAddressContraction,
   parseDaimoLink,
 } from "@daimo/common";
 import Octicons from "@expo/vector-icons/Octicons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { BarCodeScannedCallback } from "expo-barcode-scanner";
+import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { useRef, useState } from "react";
-import { Linking, Platform, Share, StyleSheet, View } from "react-native";
+import {
+  Linking,
+  Platform,
+  Pressable,
+  Share,
+  StyleSheet,
+  View,
+} from "react-native";
 import QRCode from "react-native-qrcode-svg";
 import { getAddress, isAddress } from "viem";
 
@@ -56,10 +64,23 @@ export function QRScreen(props: Props) {
 }
 
 function QRDisplay() {
+  const [recentlyCopied, setRecentlyCopied] = useState(false);
   const account = useAccount();
   if (account == null) return null;
 
   const url = formatDaimoLink({ type: "account", account: account.name });
+
+  const subtitle = recentlyCopied
+    ? "Copied address"
+    : getAddressContraction(account.address);
+
+  const onLongPress = () => {
+    console.log(`[QR] copying address ${account.address}`);
+    Clipboard.setStringAsync(account.address);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setRecentlyCopied(true);
+    setTimeout(() => setRecentlyCopied(false), 1000);
+  };
 
   return (
     <View>
@@ -67,15 +88,15 @@ function QRDisplay() {
       <Spacer h={16} />
       <View style={styles.accountShare}>
         <Spacer w={64} />
-        <View>
+        <Pressable onLongPress={onLongPress}>
           <TextCenter>
             <TextH3>{account.name}</TextH3>
           </TextCenter>
           <Spacer h={4} />
           <TextCenter>
-            <TextLight>{getAccountName({ addr: account.address })}</TextLight>
+            <TextLight>{subtitle}</TextLight>
           </TextCenter>
-        </View>
+        </Pressable>
         <ShareButton name={account.name} />
       </View>
     </View>

--- a/apps/daimo-mobile/src/view/sheet/DepositAddressBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/DepositAddressBottomSheet.tsx
@@ -1,9 +1,10 @@
-import { assert } from "@daimo/common";
+import { assert, getAddressContraction } from "@daimo/common";
 import { daimoChainFromId } from "@daimo/contract";
 import Octicons from "@expo/vector-icons/Octicons";
 import * as Clipboard from "expo-clipboard";
 import React, { useCallback, useContext, useState } from "react";
 import { StyleSheet, TouchableHighlight, View } from "react-native";
+import { Address } from "viem";
 
 import { DispatcherContext } from "../../action/dispatch";
 import { env } from "../../logic/env";
@@ -60,7 +61,7 @@ function AddressCopier({
   addr,
   disabled,
 }: {
-  addr: string;
+  addr: Address;
   disabled?: boolean;
 }) {
   const [justCopied, setJustCopied] = useState(false);
@@ -71,6 +72,8 @@ function AddressCopier({
   }, [addr]);
 
   const col = disabled ? color.gray3 : color.midnight;
+
+  const addrContracted = getAddressContraction(addr, 12);
 
   return (
     <View style={styles.address}>
@@ -84,7 +87,7 @@ function AddressCopier({
             style={[styles.addressMono, { color: col }]}
             numberOfLines={1}
           >
-            {addr}
+            {addrContracted}
           </DaimoText>
           <Octicons name="copy" size={16} color={col} />
         </View>


### PR DESCRIPTION
- show ending letters of address on deposit screen: that's what users use to authenticate the address on copying it elsewhere, and its annoying right now to not be able to see those

<img width="420" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/7212ea08-a820-45e8-9997-eaad65b25d7c">


- allow long press to copy raw address on qr screen -- noticed Daniel from Bountycaster do this and he explained he wanted this interaction since there's no easy way to get address from that screen.

<img width="256" alt="Screenshot 2024-05-01 at 9 55 37 PM" src="https://github.com/daimo-eth/daimo/assets/6984346/7a23ca91-ec2d-4b1e-a791-d20118b062d7">
<img width="256" alt="Screenshot 2024-05-01 at 9 55 41 PM" src="https://github.com/daimo-eth/daimo/assets/6984346/ecf04450-96ca-4024-8286-e4e68e143a39">
