### PR TITLE
uniswap client: workaround ethersJS bug

### DIFF
--- a/packages/daimo-api/src/network/uniswapClient.ts
+++ b/packages/daimo-api/src/network/uniswapClient.ts
@@ -62,11 +62,15 @@ export class UniswapClient {
   private swapCache: Map<string, ProposedSwap> = new Map();
 
   constructor() {
-    const l2_RPCs = process.env.DAIMO_API_L2_RPC_WS!.split(",");
+    // Use an independent HTTP RPC to work around Websocket bugs in Ethers,
+    // and by extension the Uniswap SDK:
+    // https://github.com/Uniswap/smart-order-router/issues/461
+    // https://stackoverflow.com/q/77336570
+    const uniswap_RPC = process.env.DAIMO_API_UNISWAP_RPC!;
 
-    console.log(`[UNISWAP] using L2 RPCs: ${l2_RPCs}`);
+    console.log(`[UNISWAP] using L2 RPC: ${uniswap_RPC}`);
 
-    const provider = getDefaultProvider(l2_RPCs[0]) as any; // TODO: use fallbacks?
+    const provider = getDefaultProvider(uniswap_RPC) as any; // TODO: use fallbacks?
 
     if (chainConfig.chainL2.testnet) {
       // Base Sepolia is not supported by Uniswap yet -> we test in Prod.


### PR DESCRIPTION
Observed bug: foreign coin swaps not working at all, not for DOGINME and not for USDbC, unable to reproduce on running prod API server with simulator on my local.

on investigating logs:

```
[UNISWAP] fetching swap for 0x27785Ad361898B526F37d87C4fAcFD757Ff0622F 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA
```
happens but no logs from `[UNISWAP]` even though we are supposed to always log returned information from the SDK -- it's also unclear if there was an error why `retryBackoff` did not trigger.

Googling finds other reports of similar issues, apparently from Ethers Websocket being broken.

Fix: use HTTP RPC for the Uniswap SDK instead, added env variables to prod and testnet APIs.