### PR TITLE
api: use balance from shovel instead of client

### DIFF
--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -115,7 +115,7 @@ export async function getAccountHistory(
   if (lastBlk == null) throw new Error("No latest block");
   const lastBlock = Number(lastBlk.number);
   const lastBlockTimestamp = lastBlk.timestamp;
-  const lastBalance = await homeCoinIndexer.getBalanceAt(address, lastBlock);
+  const lastBalance = homeCoinIndexer.getCurrentBalance(address);
 
   // TODO: get userops, including reverted ones. Show failed sends.
 

--- a/packages/daimo-api/src/contract/homeCoinIndexer.ts
+++ b/packages/daimo-api/src/contract/homeCoinIndexer.ts
@@ -6,7 +6,6 @@ import {
   TransferOpEvent,
   guessTimestampFromNum,
 } from "@daimo/common";
-import { erc20ABI } from "@daimo/contract";
 import { DaimoNonce } from "@daimo/userop";
 import { Pool } from "pg";
 import { Address, Hex, bytesToHex, getAddress, numberToHex } from "viem";
@@ -35,6 +34,7 @@ export interface Transfer {
 /* USDC or testUSDC stablecoin contract. Tracks transfers. */
 export class HomeCoinIndexer {
   private allTransfers: Transfer[] = [];
+  private currentBalances: Map<Address, bigint> = new Map();
 
   private listeners: ((transfers: Transfer[]) => void)[] = [];
 
@@ -103,21 +103,22 @@ export class HomeCoinIndexer {
     );
 
     this.allTransfers = this.allTransfers.concat(logs);
+    logs.forEach((t) => {
+      this.updateCurrentBalance(t.from, -t.value);
+      this.updateCurrentBalance(t.to, t.value);
+    });
+
     this.listeners.forEach((l) => l(logs));
   }
 
-  /** Get balance as of a block height. */
-  async getBalanceAt(addr: Address, blockNum: number) {
-    const blockNumber = BigInt(blockNum);
-    return await retryBackoff(`getBalanceAt-${addr}`, () =>
-      this.client.publicClient.readContract({
-        abi: erc20ABI,
-        address: chainConfig.tokenAddress,
-        functionName: "balanceOf",
-        args: [addr],
-        blockNumber,
-      })
-    );
+  updateCurrentBalance(addr: Address, delta: bigint) {
+    const currentBalance = this.currentBalances.get(addr) || 0n;
+    this.currentBalances.set(addr, currentBalance + delta);
+  }
+
+  /** Get balance as of current shovel sync. */
+  getCurrentBalance(addr: Address) {
+    return this.currentBalances.get(addr) || 0n;
   }
 
   /** Listener invoked for all past coin transfers, then for new ones. */


### PR DESCRIPTION
Fixes:
<img width="368" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/1349ad5b-3f8f-4bab-8aac-322946838d3e">

Fixes balance out of sync of displayed transfers, unclear why that could happen.