### PR TITLE
api, mobile: protect from bad finBlock sync

### DIFF
--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -113,6 +113,7 @@ export async function getAccountHistory(
   // Get the latest block + current balance.
   const lastBlk = watcher.latestBlock();
   if (lastBlk == null) throw new Error("No latest block");
+  assert(lastBlk.number >= finBlock.number, "Latest block < finalized");
   const lastBlock = Number(lastBlk.number);
   const lastBlockTimestamp = lastBlk.timestamp;
   const lastBalance = homeCoinIndexer.getCurrentBalance(address);


### PR DESCRIPTION
tested in iOS sim testnet by restarting app a couple times, various pending states etc.