### PR TITLE
release: 1.8.7

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.8.7";
+const VERSION = "1.8.8";
 
 const config: ExpoConfig = {
   owner: "daimo",

--- a/apps/daimo-mobile/src/view/screen/onboarding/ExistingUseBackupScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/ExistingUseBackupScreen.tsx
@@ -125,7 +125,7 @@ function LogInOptions({ eAcc }: { eAcc: EAccount }) {
             />
           </>
         )}
-        <Spacer h={24} />
+        <Spacer h={32} />
       </View>
     </View>
   );

--- a/apps/daimo-mobile/src/view/screen/onboarding/MissingKeyScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/MissingKeyScreen.tsx
@@ -23,6 +23,10 @@ export function MissingKeyScreen() {
 
   const [title, desc] = getKeyErrorDesc(account, keyInfo);
 
+  console.log(
+    `[ONBOARDING] MISSING KEY ${account.name}, ${account.accountKeys.length} keys, ${account.pendingKeyRotation.length} pending rotations, pubKeyHex: ${keyInfo.pubKeyHex} title: ${title}, desc: ${desc}`
+  );
+
   return (
     <View>
       <OnboardingHeader title="Missing Key" />

--- a/packages/daimo-api/Dockerfile
+++ b/packages/daimo-api/Dockerfile
@@ -7,11 +7,8 @@ FROM node:20
 # Set the working directory inside the container
 WORKDIR /usr/src/app
 
-# Copy app code
+# Copy app code and dependencies
 COPY . .
-
-# Install dependencies
-RUN npm ci
 
 # Build your application
 RUN npm run build:api


### PR DESCRIPTION
**New, much nicer receipts.**

## Release checklist

### API and webapp

- [x] Branch from `master`. **Deployed API manually; AWS not yet automated.**
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account. **Flashed Missing Key screen.**
- [x] Faucet appears automatically
- [x] Send payment
- [x] Create Payment Link, open in browser. **App error on testnet links. Need #858**
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Create Request, open in browser
- [x] Add device + Use existing onboarding (test transactions work on both devices)
- [x] Remove device
- [x] Open History
- [x] Tap transaction, view in block explorer

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account. Faucet should appear automatically. 
- [x] Send payment
- [x] Create Payment Link
- [x] Cancel Payment Link
- [x] Tap Payment Link, ensure it opens in-app
- [x] Add device + Use existing onboarding (test transactions work on both devices). **Ran into #1054**
- [x] Remove device
- [x] Create Request
- [x] Open History
- [x] Tap transaction, view in block explorer
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### Push to prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean
- [x] Sentry clean

### Prod smoke test

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
