### PR TITLE
improve api deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
           fi
 
       - name: Deploy to ECS
-        run: aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment
+        run: aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment > /dev/null
 
   eas-deploy:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,9 +84,7 @@ jobs:
           fi
 
       - name: Deploy to ECS
-        run: |
-          pip install ecs-deploy
-          ecs deploy $CLUSTER_NAME $SERVICE_NAME --timeout 900
+        run: aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment
 
   eas-deploy:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,33 +42,43 @@ jobs:
         with:
           platforms: arm64
 
-      - name: Build, tag, and push docker image to Amazon ECR
+      - name: Check for existing image with GIT_SHA
         env:
           GIT_SHA: ${{ github.sha }}
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPO: ${{ vars.AWS_ECR_API_REPO }}
         run: |
-          # Check if image exists in ECR with GIT_SHA tag
-          image_manifest=$(aws ecr batch-get-image --repository-name $REPO --image-ids imageTag=$GIT_SHA --query 'images[0].imageManifest' --output text)
+          image_manifest=$(aws ecr batch-get-image --repository-name $REPO --image-ids imageTag=$GIT_SHA --query 'images[0].imageManifest')
+          echo "IMAGE_MANIFEST=$image_manifest" >> $GITHUB_ENV
 
-          if [[ $image_manifest == "None" ]]; then
-            echo "Image does not exist with tag \"$GIT_SHA\", building and pushing new image."
-            docker build --platform linux/arm64 -t $REGISTRY/$REPO:$GIT_SHA -t $REGISTRY/$REPO:$IMAGE_TAG -f packages/daimo-api/Dockerfile .
-            docker push $REGISTRY/$REPO:$GIT_SHA
-            docker push $REGISTRY/$REPO:$IMAGE_TAG
+      - if: env.IMAGE_MANIFEST == 'null'
+        name: Build, tag, and push docker image to Amazon ECR
+        env:
+          GIT_SHA: ${{ github.sha }}
+          IMAGE_NAME: ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_API_REPO }}
+        run: |
+          echo "Image does not exist with tag \"$GIT_SHA\", building and pushing new image."
+          docker build --platform linux/arm64 -t $IMAGE_NAME:$GIT_SHA -t $IMAGE_NAME:$IMAGE_TAG -f packages/daimo-api/Dockerfile .
+          docker push $IMAGE_NAME:$GIT_SHA
+          docker push $IMAGE_NAME:$IMAGE_TAG
+
+      - if: env.IMAGE_MANIFEST != 'null'
+        name: Add tag to existing image.
+        env:
+          REPO: ${{ vars.AWS_ECR_API_REPO }}
+        run: |
+          echo "Image exists with GIT_SHA tag, adding tag \"$IMAGE_TAG\" to it."
+          IMAGE_MANIFEST=$(echo $IMAGE_MANIFEST | jq -c -r)
+
+          set +e
+          output=$(aws ecr put-image --repository-name $REPO --image-tag $IMAGE_TAG --image-manifest "$IMAGE_MANIFEST" 2>&1)
+          status=$?
+          set -e
+
+          if [[ $status -ne 0 && ! "$output" =~ "ImageAlreadyExistsException" ]]; then
+            echo $output
+            exit $status
           else
-            echo "Image exists with tag \"$GIT_SHA\", adding tag \"$IMAGE_TAG\" to it."
-            set +e
-            output=$(aws ecr put-image --repository-name $REPO --image-tag $IMAGE_TAG --image-manifest "$image_manifest" 2>&1)
-            status=$?
-            set -e
-
-            if [[ $status -ne 0 && ! "$output" =~ "ImageAlreadyExistsException" ]]; then
-              echo $output
-              exit $status
-            else
-              echo "Image already tagged with \"$IMAGE_TAG.\""
-            fi
+            echo "Image already tagged with \"$IMAGE_TAG.\""
           fi
 
       - name: Deploy to ECS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,11 +45,31 @@ jobs:
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           GIT_SHA: ${{ github.sha }}
-          IMAGE_NAME: ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_API_REPO }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPO: ${{ vars.AWS_ECR_API_REPO }}
         run: |
-          docker build --platform linux/arm64 -t $IMAGE_NAME:$GIT_SHA -t $IMAGE_NAME:$IMAGE_TAG -f packages/daimo-api/Dockerfile .
-          docker push $IMAGE_NAME:$GIT_SHA
-          docker push $IMAGE_NAME:$IMAGE_TAG
+          # Check if image exists in ECR with GIT_SHA tag
+          image_manifest=$(aws ecr batch-get-image --repository-name $REPO --image-ids imageTag=$GIT_SHA --query 'images[0].imageManifest' --output text)
+
+          if [[ $image_manifest == "None" ]]; then
+            echo "Image does not exist with tag \"$GIT_SHA\", building and pushing new image."
+            docker build --platform linux/arm64 -t $REGISTRY/$REPO:$GIT_SHA -t $REGISTRY/$REPO:$IMAGE_TAG -f packages/daimo-api/Dockerfile .
+            docker push $REGISTRY/$REPO:$GIT_SHA
+            docker push $REGISTRY/$REPO:$IMAGE_TAG
+          else
+            echo "Image exists with tag \"$GIT_SHA\", adding tag \"$IMAGE_TAG\" to it."
+            set +e
+            output=$(aws ecr put-image --repository-name $REPO --image-tag $IMAGE_TAG --image-manifest "$image_manifest" 2>&1)
+            status=$?
+            set -e
+
+            if [[ $status -ne 0 && ! "$output" =~ "ImageAlreadyExistsException" ]]; then
+              echo $output
+              exit $status
+            else
+              echo "Image already tagged with \"$IMAGE_TAG.\""
+            fi
+          fi
 
       - name: Deploy to ECS
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha
           context: .
           file: ./packages/daimo-api/Dockerfile
           platforms: linux/arm64

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,11 +76,13 @@ jobs:
           status=$?
           set -e
 
-          if [[ $status -ne 0 && ! "$output" =~ "ImageAlreadyExistsException" ]]; then
-            echo $output
-            exit $status
-          else
-            echo "Image already tagged with \"$IMAGE_TAG.\""
+          if [[ $status -ne 0 ]]; then
+            if [[ ! "$output" =~ "ImageAlreadyExistsException" ]]; then
+              echo $output
+              exit $status
+            else
+              echo "Image already tagged with \"$IMAGE_TAG.\""
+            fi
           fi
 
       - name: Deploy to ECS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,11 +37,6 @@ jobs:
             echo "SERVICE_NAME=${{ vars.AWS_ECS_API_SERVICE_STAGING }}" >> $GITHUB_ENV
           fi
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: arm64
-
       - name: Check for existing image with GIT_SHA
         env:
           GIT_SHA: ${{ github.sha }}
@@ -51,15 +46,22 @@ jobs:
           echo "IMAGE_MANIFEST=$image_manifest" >> $GITHUB_ENV
 
       - if: env.IMAGE_MANIFEST == 'null'
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - if: env.IMAGE_MANIFEST == 'null'
         name: Build, tag, and push docker image to Amazon ECR
-        env:
-          GIT_SHA: ${{ github.sha }}
-          IMAGE_NAME: ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_API_REPO }}
-        run: |
-          echo "Image does not exist with tag \"$GIT_SHA\", building and pushing new image."
-          docker build --platform linux/arm64 -t $IMAGE_NAME:$GIT_SHA -t $IMAGE_NAME:$IMAGE_TAG -f packages/daimo-api/Dockerfile .
-          docker push $IMAGE_NAME:$GIT_SHA
-          docker push $IMAGE_NAME:$IMAGE_TAG
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: ./packages/daimo-api/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_API_REPO }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_API_REPO }}:${{ env.IMAGE_TAG }}
 
       - if: env.IMAGE_MANIFEST != 'null'
         name: Add tag to existing image.


### PR DESCRIPTION
Updates cd so that it first checks whether an image exists with the git sha so that the build/push can be skipped. If it needs to deploy, it will build and deploy using docker, utilizing caching.