### PR TITLE
api: disable ethIndexer for now, bugs

### DIFF
--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -101,7 +101,9 @@ async function main() {
     [noteIndexer, requestIndexer, foreignCoinIndexer],
     [homeCoinIndexer]
   );
-  shovelWatcher.slowAdd(ethIndexer);
+
+  // Disable ethIndexer for now
+  // shovelWatcher.slowAdd(ethIndexer);
 
   // Initialize in background
   (async () => {


### PR DESCRIPTION
Looks like some weird bugs due Quicknode breaking and not working well with the `updateLastProcessedCheckStale` which doesn't account for it -- will just disable for now and bring it back in #1035 properly, additionally fixing #1082.

Tested API still works fine.