### PR TITLE
ignore invalid CoinGecko addresses

### DIFF
--- a/packages/daimo-api/src/server/coinList.ts
+++ b/packages/daimo-api/src/server/coinList.ts
@@ -1,5 +1,5 @@
 import { ForeignCoin, USDbC, assert } from "@daimo/common";
-import { Address, getAddress } from "viem";
+import { Address, getAddress, isAddress } from "viem";
 
 import { chainConfig } from "../env";
 
@@ -29,6 +29,7 @@ export async function fetchTokenList(): Promise<Map<Address, ForeignToken>> {
   for (const token of tokenList.tokens) {
     assert(token.chainId === 8453, "Only Base supported");
     const largeLogo = token.logoURI?.split("?")[0].replace("thumb", "large");
+    if (!isAddress(token.address)) continue; // ignore invalid addresses that Coingecko returns
     const addr = getAddress(token.address);
     if (addr === chainConfig.tokenAddress) continue;
 


### PR DESCRIPTION
Handles invalid addresses such as:

<img width="999" alt="image" src="https://github.com/daimo-eth/daimo/assets/5856011/0408d6e4-3749-4d78-8975-c0ebd3c03fb7">
