### PR TITLE
feat: add profile picture to link preview

### DIFF
--- a/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { daimoLinkBaseV2 } from "@daimo/common";
 import { Metadata } from "next";
 import Image from "next/image";
@@ -5,6 +6,7 @@ import Image from "next/image";
 import { CallToAction } from "../../../components/CallToAction";
 import { Providers, chainsDaimoL2 } from "../../../components/Providers";
 import { getAbsoluteUrl } from "../../../utils/getAbsoluteUrl";
+import { loadPFPUrl } from "../../../utils/getProfilePicture";
 import {
   createMetadata,
   createMetadataForLinkStatus,
@@ -54,6 +56,7 @@ async function LinkPageInner(props: LinkProps) {
       title: "Daimo",
       description: "Payments on Ethereum",
     };
+  const pfp = name ? await loadPFPUrl(name) : undefined;
 
   return (
     <main className="max-w-md mx-auto px-4">
@@ -63,9 +66,29 @@ async function LinkPageInner(props: LinkProps) {
 
         <div className="h-12" />
 
-        <div className="text-xl font-semibold">
-          {name && <span>{name}</span>}
-          {action && <span className="text-grayMid">{" " + action}</span>}
+        <div className="flex text-xl font-semibold justify-center items-center">
+          <div className="flex flex-row gap-x-2">
+            {pfp && (
+              <div
+                className="flex h-[32px] w-[32px]"
+                style={{ position: "relative" }}
+              >
+                <img
+                  src={pfp}
+                  alt={"Profile"}
+                  style={{
+                    objectFit: "cover",
+                    borderRadius: "100px",
+                  }}
+                />
+              </div>
+            )}
+
+            <div className="flex items-center gap-x-1">
+              {name && <span>{name}</span>}
+              {action && <span className="text-grayMid">{" " + action}</span>}
+            </div>
+          </div>
         </div>
         {dollars && (
           <>

--- a/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
@@ -98,7 +98,7 @@ async function LinkPageInner(props: LinkProps) {
 
         <div className="h-12" />
 
-        <div className="text-xl font-semibold">
+        <div className="flex text-xl font-semibold justify-center items-center">
           {name && <span>{name}</span>}
           {action && <span className="text-grayMid">{" " + action}</span>}
         </div>
@@ -188,6 +188,7 @@ async function loadTitleDesc(url: string): Promise<TitleDesc | null> {
   switch (res.link.type) {
     case "account": {
       const { account } = res as DaimoAccountStatus;
+      console.log(`[LINK] got account ${JSON.stringify(account)}`);
       return {
         name: getAccountName(account),
         description: "Get Daimo to send or receive payments",

--- a/apps/daimo-web/src/app/preview/route.tsx
+++ b/apps/daimo-web/src/app/preview/route.tsx
@@ -2,6 +2,7 @@
 import { ImageResponse } from "@vercel/og";
 
 import { LinkPreviewImg } from "../../components/image-gen/LinkPreview";
+import { loadPFPUrl } from "../../utils/getProfilePicture";
 
 export const runtime = "edge";
 
@@ -21,9 +22,14 @@ export async function GET(request: Request) {
     : undefined;
   const paidBy = searchParams.get("paidBy") || undefined;
   const cancelled = !!searchParams.get("cancelled");
+  const pfpUrl = name ? await loadPFPUrl(name) : undefined;
 
   return new ImageResponse(
-    <LinkPreviewImg {...{ name, action, dollars, paidBy, cancelled }} />,
+    (
+      <LinkPreviewImg
+        {...{ name, action, dollars, pfpUrl, paidBy, cancelled }}
+      />
+    ),
     {
       width: 1200,
       height: 630,

--- a/apps/daimo-web/src/components/image-gen/LinkPreview.tsx
+++ b/apps/daimo-web/src/components/image-gen/LinkPreview.tsx
@@ -7,12 +7,14 @@ export function LinkPreviewImg({
   dollars,
   paidBy,
   cancelled,
+  pfpUrl,
 }: {
   name: string;
   action?: string;
   dollars?: string;
   paidBy?: string;
   cancelled?: boolean;
+  pfpUrl?: string;
 }) {
   return (
     <div
@@ -37,7 +39,12 @@ export function LinkPreviewImg({
           flexDirection: "column",
         }}
       >
-        <Content name={name} action={action} dollars={dollars} />
+        <Content
+          name={name}
+          action={action}
+          dollars={dollars}
+          pfpUrl={pfpUrl}
+        />
         <Footer paidBy={paidBy} cancelled={cancelled} />
       </div>
     </div>
@@ -48,10 +55,12 @@ function Content({
   name,
   action,
   dollars,
+  pfpUrl,
 }: {
   name: string;
   action: string | undefined;
   dollars: string | undefined;
+  pfpUrl?: string;
 }) {
   return (
     <div
@@ -73,7 +82,7 @@ function Content({
           paddingRight: "24px",
         }}
       >
-        <UserBubble name={name} />
+        <UserBubble name={name} pfpUrl={pfpUrl} />
       </div>
       <div
         style={{

--- a/apps/daimo-web/src/components/image-gen/UserBubble.tsx
+++ b/apps/daimo-web/src/components/image-gen/UserBubble.tsx
@@ -1,8 +1,46 @@
-// TODO: support rich profile custom images
-export function UserBubble({ name }: { name: string }) {
+/* eslint-disable @next/next/no-img-element */
+export function UserBubble({
+  name,
+  pfpUrl,
+}: {
+  name: string;
+  pfpUrl?: string;
+}) {
   const inBubbleText = String.fromCodePoint(
     name.codePointAt(0) || "?".charCodeAt(0),
   ).toUpperCase();
+
+  // Show pfp if it exists
+  if (pfpUrl) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          width: "256px",
+          height: "256px",
+          borderRadius: "50%",
+        }}
+      >
+        {pfpUrl && (
+          <div
+            style={{
+              display: "flex",
+              width: "256px",
+              height: "256px",
+              borderRadius: "50%",
+              overflow: "hidden",
+            }}
+          >
+            <img
+              src={`${pfpUrl}`}
+              alt={"Profile"}
+              style={{ width: "256px", height: "256px", objectFit: "cover" }}
+            ></img>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/daimo-web/src/utils/getProfilePicture.ts
+++ b/apps/daimo-web/src/utils/getProfilePicture.ts
@@ -8,10 +8,12 @@ export async function loadPFPUrl(name: string): Promise<string | undefined> {
   const profilePicture = res.linkedAccounts?.[0]?.pfpUrl;
 
   if (profilePicture == null) {
-    console.log(`[PFP] no PFP found for ${addr}`);
+    console.log(`[PFP] no PFP found for ${name} (${addr})`);
     return undefined;
   }
 
-  console.log(`[PFP] ${addr} fetched profile picture URL ${profilePicture}`);
+  console.log(
+    `[PFP] ${name} (${addr}) fetched profile picture URL ${profilePicture}`
+  );
   return profilePicture;
 }

--- a/apps/daimo-web/src/utils/getProfilePicture.ts
+++ b/apps/daimo-web/src/utils/getProfilePicture.ts
@@ -1,0 +1,16 @@
+import { rpc } from "./rpc";
+
+// Fetches a profile picture from a Daimo account name.
+export async function loadPFPUrl(name: string): Promise<string | undefined> {
+  const addr = await rpc.resolveName.query({ name });
+  if (addr == null) return undefined;
+  const res = await rpc.getEthereumAccount.query({ addr });
+  const profilePicture = res.linkedAccounts?.[0]?.pfpUrl;
+
+  if (profilePicture == null) {
+    console.log(`[PROFILE] no PFP for ${addr}}`);
+    return undefined;
+  }
+
+  return profilePicture;
+}

--- a/apps/daimo-web/src/utils/getProfilePicture.ts
+++ b/apps/daimo-web/src/utils/getProfilePicture.ts
@@ -8,9 +8,10 @@ export async function loadPFPUrl(name: string): Promise<string | undefined> {
   const profilePicture = res.linkedAccounts?.[0]?.pfpUrl;
 
   if (profilePicture == null) {
-    console.log(`[PROFILE] no PFP for ${addr}}`);
+    console.log(`[PFP] no PFP found for ${addr}`);
     return undefined;
   }
 
+  console.log(`[PFP] ${addr} fetched profile picture URL ${profilePicture}`);
   return profilePicture;
 }


### PR DESCRIPTION
Adds profile picture to link preview if a profile picture exists for the given Daimo account. 

**Link Preview**
Before:
<img width="600" alt="Screenshot 2024-06-03 at 10 38 52 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/9e6b3957-64d8-4ebe-b3f7-9e943c527dff">

After:
<img width="600" alt="Screenshot 2024-06-03 at 10 31 16 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/a66c4b2f-fd8b-4146-ac2a-d15e9ac3717f">

**Web page**
Before:
<img width="300" alt="Screenshot 2024-06-03 at 11 04 20 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/de51fd84-50e7-49c1-acc4-48f6cba5dfbc">

After:
<img width="300" alt="Screenshot 2024-06-03 at 11 04 35 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/9a20686e-c09d-4062-86ab-60d6301bf092">