### PR TITLE
[fix] RPC downtime error handling for ETH transfers

### DIFF
--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -52,13 +52,19 @@ export class ETHIndexer extends Indexer {
       if (blockNum < chainConfig.offChainUtilsDeployBlock) {
         return new Array(addrs.length).fill(0n) as bigint[];
       } else {
-        return await this.vc.publicClient.readContract({
-          abi: daimoOffchainUtilsABI,
-          address: daimoOffchainUtilsAddress,
-          functionName: "batchGetETHBalances",
-          args: [addrs],
-          blockNumber: BigInt(blockNum),
-        });
+        try {
+          const ethBalances = await this.vc.publicClient.readContract({
+            abi: daimoOffchainUtilsABI,
+            address: daimoOffchainUtilsAddress,
+            functionName: "batchGetETHBalances",
+            args: [addrs],
+            blockNumber: BigInt(blockNum),
+          });
+          return ethBalances;
+        } catch (e) {
+          console.log(`[ETH INDEXER] batchGetETHBalances error: ${e}`);
+          return new Array(addrs.length).fill(0n) as bigint[]; // unsure if this is the appropriate response
+        }
       }
     };
 

--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -74,16 +74,16 @@ export class ETHIndexer extends Indexer {
 
       // Calculate difference between fetched balance and latest cached balance.
       for (let i = 0; i < batch.length; i++) {
-        const balance = this.latestBalances.get(batch[i]);
-        if (balance == null) continue;
-
-        const oldBalance = this.latestBalances.get(batch[i])![0];
+        const oldBalance = this.latestBalances.has(batch[i])
+          ? this.latestBalances.get(batch[i])![0]
+          : 0n;
         const balanceDiff = newBalances[i] - oldBalance;
 
         // If received more ETH, add to balance diffs.
         if (balanceDiff > 0n) {
           balanceDiffs.set(batch[i], balanceDiff);
         }
+
         // Update cache with new balance and currentblock number.
         this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
       }

--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -74,14 +74,15 @@ export class ETHIndexer extends Indexer {
 
       // Calculate difference between fetched balance and latest cached balance.
       for (let i = 0; i < batch.length; i++) {
-        if (this.latestBalances.has(batch[i])) {
-          const oldBalance = this.latestBalances.get(batch[i])![0];
-          const balanceDiff = newBalances[i] - oldBalance;
+        const balance = this.latestBalances.get(batch[i]);
+        if (balance == null) continue;
 
-          // If received more ETH, add to balance diffs.
-          if (balanceDiff > 0n) {
-            balanceDiffs.set(batch[i], balanceDiff);
-          }
+        const oldBalance = this.latestBalances.get(batch[i])![0];
+        const balanceDiff = newBalances[i] - oldBalance;
+
+        // If received more ETH, add to balance diffs.
+        if (balanceDiff > 0n) {
+          balanceDiffs.set(batch[i], balanceDiff);
         }
         // Update cache with new balance and currentblock number.
         this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
@@ -94,7 +95,6 @@ export class ETHIndexer extends Indexer {
   // (from, to] since Shovel doesn't support indexing them.
   async load(_: Pool, from: number, to: number) {
     const startTime = Date.now();
-
     const allAddrs = this.nameReg.getAllDAccounts().map((a) => a.addr);
 
     // Query differences in latest balances and starting balances for all accounts

--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -82,8 +82,6 @@ export class ETHIndexer extends Indexer {
           if (balanceDiff > 0n) {
             balanceDiffs.set(batch[i], balanceDiff);
           }
-        } else {
-          balanceDiffs.set(batch[i], newBalances[i] - 0n);
         }
         // Update cache with new balance and currentblock number.
         this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -102,8 +102,9 @@ async function main() {
     [homeCoinIndexer]
   );
 
-  // Disable ethIndexer for now
-  // shovelWatcher.slowAdd(ethIndexer);
+  // ethIndexer can be spotty depending on RPC errors.
+  // TODO: merge ethIndexer and foreignCoinIndexer into one as shovel now supports both.
+  shovelWatcher.slowAdd(ethIndexer);
 
   // Initialize in background
   (async () => {

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -103,7 +103,6 @@ async function main() {
   );
 
   // ethIndexer can be spotty depending on RPC errors.
-  // TODO: merge ethIndexer and foreignCoinIndexer into one as shovel now supports both.
   shovelWatcher.slowAdd(ethIndexer);
 
   // Initialize in background


### PR DESCRIPTION
Eth Transfers are not showing up in-app due to the ethIndexer being disabled because of RPC failures (see https://github.com/daimo-eth/daimo/pull/1089).

This PR simplifies ethIndexer to simply fetch the latest cached balance for the given address. If there is a positive balance difference between the cached balanced and the new balance, then adds to newTransfers.