### PR TITLE
add bot & clippy to cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,76 @@ jobs:
       - name: Deploy to ECS
         run: aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment > /dev/null
 
+  bot-deploy:
+    if: github.ref == 'refs/heads/master'
+    name: Bot Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          mask-aws-account-id: true
+
+      - id: login-ecr
+        name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=gha
+          cache-to: type=gha
+          context: .
+          file: ./apps/daimo-bot/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_BOT_REPO }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_BOT_REPO }}:latest
+
+  clippy-deploy:
+    if: github.ref == 'refs/heads/master'
+    name: Clippy Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          mask-aws-account-id: true
+
+      - id: login-ecr
+        name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=gha
+          cache-to: type=gha
+          context: .
+          file: ./apps/daimo-clippy/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_CLIPPY_REPO }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.AWS_ECR_CLIPPY_REPO }}:latest
+
   eas-deploy:
     if: github.ref == 'refs/heads/master'
     name: EAS Deploy

--- a/apps/daimo-bot/Dockerfile
+++ b/apps/daimo-bot/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Node.js 20 image.
+FROM node:20
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy app code
+COPY . .
+
+# Install dependencies
+RUN npm ci
+
+# Build app
+RUN npm run build:bot
+
+# Expose the port the app runs on
+EXPOSE 4000
+
+# Start app
+CMD ["npm", "start", "--prefix", "./apps/daimo-bot"]

--- a/apps/daimo-clippy/Dockerfile
+++ b/apps/daimo-clippy/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Node.js 20 image.
+FROM node:20
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy app code
+COPY . .
+
+# Install dependencies
+RUN npm ci
+
+# Build app
+RUN npm run build:clippy
+
+# Expose the port the app runs on
+EXPOSE 4200
+
+# Start app
+CMD ["npm", "start", "--prefix", "./apps/daimo-clippy"]


### PR DESCRIPTION
Couldn't find a nice way to share the common steps between jobs so just repeated them. Also adds `ts-node` as a devDependency to clippy matching the bot setup (`tsx` was failing to run on the docker image).