### PR TITLE
clippy: Add ETH transfer notifications to clippy

### DIFF
--- a/packages/daimo-api/src/server/cron.ts
+++ b/packages/daimo-api/src/server/cron.ts
@@ -16,6 +16,7 @@ import { Constants } from "userop";
 import { Hex, formatEther, getAddress } from "viem";
 
 import { Telemetry } from "./telemetry";
+import { ETHIndexer, ETHTransfer } from "../contract/ethIndexer";
 import {
   ForeignCoinIndexer,
   ForeignTokenTransfer,
@@ -32,6 +33,7 @@ export class Crontab {
     private vc: ViemClient,
     private homeCoinIndexer: HomeCoinIndexer,
     private foreignCoinIndexer: ForeignCoinIndexer,
+    private ethIndexer: ETHIndexer,
     private nameRegistry: NameRegistry,
     private telemetry: Telemetry
   ) {}
@@ -44,6 +46,7 @@ export class Crontab {
     ];
     this.homeCoinIndexer.addListener(this.pipeTransfers);
     this.foreignCoinIndexer.addListener(this.pipeForeignCoinTransfers);
+    this.ethIndexer.addListener(this.pipeEthTransfers);
 
     this.cronJobs.forEach((job) => job.start());
   }
@@ -154,6 +157,12 @@ export class Crontab {
     }
   };
 
+  private pipeEthTransfers = (logs: ETHTransfer[]) => {
+    for (const transfer of logs) {
+      this.postRecentEthTransfer(transfer);
+    }
+  };
+
   async postRecentTransfer(opEvent: DisplayOpEvent) {
     const fromName = this.nameRegistry.resolveDaimoNameForAddr(opEvent.from);
     const toName = this.nameRegistry.resolveDaimoNameForAddr(opEvent.to);
@@ -203,6 +212,22 @@ export class Crontab {
     );
     this.telemetry.recordClippy(
       `Forex Transfer: ${fromDisplayName} -> ${toDisplayName} ${humanReadableValue} ${transfer.foreignToken.symbol} `
+    );
+  }
+
+  // Track ETH received by a user (no "from" address because currently batch receives balance difference).
+  async postRecentEthTransfer(transfer: ETHTransfer) {
+    const toName = this.nameRegistry.resolveDaimoNameForAddr(transfer.to);
+
+    if (toName == null) return;
+
+    const toDisplayName = getAccountName(
+      await this.nameRegistry.getEAccount(transfer.to)
+    );
+
+    const humanReadableValue = formatEther(transfer.value);
+    this.telemetry.recordClippy(
+      `ETH Transfer: ${toDisplayName} received ${humanReadableValue} ETH`
     );
   }
 }

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -79,6 +79,7 @@ async function main() {
     vc,
     homeCoinIndexer,
     foreignCoinIndexer,
+    ethIndexer,
     nameReg,
     monitor
   );


### PR DESCRIPTION
Adds ETH transfer notifications to clippy to track when a user receives ETH. Currently not being reported by Clippy.

<img width="588" alt="Screenshot 2024-06-06 at 1 43 47 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/a6b451f1-2d48-405f-b404-e02439ecb138">
