### PR TITLE
web: cache bust previews without profile pics

### DIFF
--- a/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
@@ -61,7 +61,7 @@ function getPreviewURL(
   if (uriEncodedAction)
     previewURL = previewURL.concat(`&action=${uriEncodedAction}`);
   if (dollars) previewURL = previewURL.concat(`&dollars=${dollars}`);
-  previewURL = previewURL.concat(`&v=2`); // cache bust images with old logo
+  previewURL = previewURL.concat(`&v=3`); // cache bust images without profile pics
   return previewURL;
 }
 

--- a/apps/daimo-web/src/utils/linkMetaTags.ts
+++ b/apps/daimo-web/src/utils/linkMetaTags.ts
@@ -111,7 +111,7 @@ function getPreviewURL(
   if (cancelled) {
     previewURL = previewURL.concat(`&cancelled=true`);
   }
-  previewURL = previewURL.concat(`&v=2`); // cache bust images with old logo
+  previewURL = previewURL.concat(`&v=3`); // cache bust images without profile pics
   return previewURL;
 }
 


### PR DESCRIPTION
this is the only way I know to cache bust telegram link preview images, also did a "purge cache" in vercel project

<img width="290" alt="image" src="https://github.com/daimo-eth/daimo/assets/6984346/d02e448e-8fd6-4117-83bf-b6daeb87e417">
