### PR TITLE
api: ethIndexer caching changes

### DIFF
--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -77,15 +77,15 @@ export class ETHIndexer extends Indexer {
         const oldBalance = this.latestBalances.has(batch[i])
           ? this.latestBalances.get(batch[i])![0]
           : 0n;
-        const balanceDiff = newBalances[i] - oldBalance;
+        const newBalance = newBalances[i];
 
         // If received more ETH, add to balance diffs.
-        if (balanceDiff > 0n) {
-          balanceDiffs.set(batch[i], balanceDiff);
+        if (newBalance > oldBalance) {
+          balanceDiffs.set(batch[i], newBalance - oldBalance);
         }
 
         // Update cache with new balance and currentblock number if diff is non-zero.
-        if (balanceDiff !== 0n) {
+        if (newBalance !== oldBalance) {
           this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
         }
       }

--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -84,8 +84,10 @@ export class ETHIndexer extends Indexer {
           balanceDiffs.set(batch[i], balanceDiff);
         }
 
-        // Update cache with new balance and currentblock number.
-        this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
+        // Update cache with new balance and currentblock number if diff is non-zero.
+        if (balanceDiff !== 0n) {
+          this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
+        }
       }
     }
     return balanceDiffs;

--- a/packages/daimo-api/src/contract/ethIndexer.ts
+++ b/packages/daimo-api/src/contract/ethIndexer.ts
@@ -86,7 +86,7 @@ export class ETHIndexer extends Indexer {
 
         // Update cache with new balance and currentblock number if diff is non-zero.
         if (newBalance !== oldBalance) {
-          this.latestBalances.set(batch[i], [newBalances[i], toBlockNum]);
+          this.latestBalances.set(batch[i], [newBalance, toBlockNum]);
         }
       }
     }

--- a/packages/daimo-api/src/server/cron.ts
+++ b/packages/daimo-api/src/server/cron.ts
@@ -221,13 +221,9 @@ export class Crontab {
 
     if (toName == null) return;
 
-    const toDisplayName = getAccountName(
-      await this.nameRegistry.getEAccount(transfer.to)
-    );
-
     const humanReadableValue = formatEther(transfer.value);
     this.telemetry.recordClippy(
-      `ETH Transfer: ${toDisplayName} received ${humanReadableValue} ETH`
+      `ETH Transfer: ${toName} received ${humanReadableValue} ETH`
     );
   }
 }


### PR DESCRIPTION
Only change cache when there is a balance difference instead of updating cache for all accounts every index.