### PR TITLE
sentry: filter out API "not ready" logging errors

### DIFF
--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -109,7 +109,7 @@ export function createRouter(
     if (!notifier.isInitialized) {
       throw new TRPCError({
         code: "PRECONDITION_FAILED",
-        message: "not ready",
+        message: "API not ready",
       });
     }
     return opts.next();

--- a/packages/daimo-api/src/server/telemetry.ts
+++ b/packages/daimo-api/src/server/telemetry.ts
@@ -65,6 +65,8 @@ export class Telemetry {
     } else {
       Sentry.init({
         dsn: sentryDSN,
+        // Don't send API server "not ready" errors to Sentry.
+        ignoreErrors: ["API not ready"],
         integrations: [
           new Sentry.Integrations.Postgres(),
           nodeProfilingIntegration(),


### PR DESCRIPTION
Addresses https://github.com/daimo-eth/daimo/issues/1133.

API not ready should not be sent to Sentry as an Error. 