### PR TITLE
Use Websocket in Shovel for realtime block ingestion

### DIFF
--- a/packages/daimo-contract/src/shovel/config.json
+++ b/packages/daimo-contract/src/shovel/config.json
@@ -6,6 +6,7 @@
       "name": "$CHAIN_NAME",
       "chain_id": "$CHAIN_ID",
       "url": "$CHAIN_RPC_URL",
+      "ws_url": "$CHAIN_RPC_WS_URL",
       "batch_size": 100,
       "concurrency": 4
     }
@@ -1210,3 +1211,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
Simple but effective change.

```
eth_sources[].ws_url
An optional URL that points to a Websocket JSON RPC API. If this URL is set Shovel will use the websocket to get the latest block instead of calling eth_getBlockByNumber. If the websocket fails for any reason Shovel will fallback on the HTTP based API
```

More: https://www.indexsupply.com/shovel/docs/#config-eth-sources-ws-url

This requires adding CHAIN_RPC_WS_URL env var to Shovel service.

closes https://github.com/daimo-eth/daimo/issues/1109