### PR TITLE
api, mobile: refactor opEvent to Clog

### DIFF
--- a/apps/daimo-mobile/src/action/useSendAsync.ts
+++ b/apps/daimo-mobile/src/action/useSendAsync.ts
@@ -1,6 +1,6 @@
 import {
   DaimoInviteCodeStatus,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   OpEvent,
   PendingOpEvent,
@@ -140,7 +140,9 @@ export function useSendAsync({
  *  transfer to history and merges any new named accounts. */
 export function transferAccountTransform(namedAccounts: EAccount[]) {
   return (account: Account, pendingOp: OpEvent): Account => {
-    assert(["transfer", "createLink", "claimLink"].includes(pendingOp.type));
+    assert(
+      ["transfer", "createLink", "claimLink", "swap"].includes(pendingOp.type)
+    );
     // Filter to new named accounts only
     const findAccount = (addr: Address) =>
       account.namedAccounts.find((a) => a.addr === addr);
@@ -149,10 +151,7 @@ export function transferAccountTransform(namedAccounts: EAccount[]) {
 
     return {
       ...account,
-      recentTransfers: [
-        ...account.recentTransfers,
-        pendingOp as DisplayOpEvent,
-      ],
+      recentTransfers: [...account.recentTransfers, pendingOp as TransferClog],
       namedAccounts: [...account.namedAccounts, ...namedAccounts],
     };
   };

--- a/apps/daimo-mobile/src/action/useSendAsync.ts
+++ b/apps/daimo-mobile/src/action/useSendAsync.ts
@@ -141,7 +141,13 @@ export function useSendAsync({
 export function transferAccountTransform(namedAccounts: EAccount[]) {
   return (account: Account, pendingOp: OpEvent): Account => {
     assert(
-      ["transfer", "createLink", "claimLink", "swap"].includes(pendingOp.type)
+      [
+        "transfer",
+        "createLink",
+        "claimLink",
+        "inboundSwap",
+        "outboundSwap",
+      ].includes(pendingOp.type)
     );
     // Filter to new named accounts only
     const findAccount = (addr: Address) =>

--- a/apps/daimo-mobile/src/common/nav.ts
+++ b/apps/daimo-mobile/src/common/nav.ts
@@ -7,7 +7,7 @@ import {
   DaimoLinkRequest,
   DaimoLinkRequestV2,
   DaimoLinkTag,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   ForeignToken,
   getEAccountStr,
@@ -59,7 +59,7 @@ export type ParamListHome = {
   Profile:
     | { eAcc: EAccount; inviterEAcc: EAccount | undefined }
     | { link: DaimoLinkAccount | DaimoLinkInviteCode };
-  HistoryOp: { op: DisplayOpEvent };
+  HistoryOp: { op: TransferClog };
   Receive: { autoFocus: boolean; fulfiller?: DaimoContact };
   Note: { link: DaimoLinkNote | DaimoLinkNoteV2 };
   ReceiveNav: undefined;
@@ -96,7 +96,7 @@ export type ParamListSend = {
   Profile:
     | { eAcc: EAccount; inviterEAcc: EAccount | undefined }
     | { link: DaimoLinkAccount };
-  HistoryOp: { op: DisplayOpEvent };
+  HistoryOp: { op: TransferClog };
 };
 
 export type ParamListDeposit = {
@@ -158,7 +158,7 @@ export const defaultError = {
 export type ParamListBottomSheet = {
   BottomSheetList: undefined;
   BottomSheetHistoryOp: {
-    op: DisplayOpEvent;
+    op: TransferClog;
     shouldAddInset: boolean;
   };
 };

--- a/apps/daimo-mobile/src/logic/accountManager.ts
+++ b/apps/daimo-mobile/src/logic/accountManager.ts
@@ -3,7 +3,7 @@ import {
   DaimoLink,
   DaimoLinkNoteV2,
   DaimoNoteStatus,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   OpStatus,
   assert,
@@ -354,7 +354,7 @@ class AccountManager {
         noteStatus,
         to: address,
         txHash,
-      } as DisplayOpEvent;
+      } as TransferClog;
 
       this.transform((a) => ({
         ...a,

--- a/apps/daimo-mobile/src/storage/account.ts
+++ b/apps/daimo-mobile/src/storage/account.ts
@@ -5,7 +5,6 @@ import {
   DaimoInviteCodeStatus,
   DaimoLinkNoteV2,
   DaimoRequestV2Status,
-  DisplayOpEvent,
   EAccount,
   KeyData,
   KeyRotationOpEvent,
@@ -13,6 +12,7 @@ import {
   ProposedSwap,
   RecommendedExchange,
   SuggestedAction,
+  TransferClog,
   assert,
   now,
 } from "@daimo/common";
@@ -67,7 +67,7 @@ export type Account = {
   /** The latest finalized block as of the most recent sync. */
   lastFinalizedBlock: number;
   /** Transfers to/from other Daimo accounts & other Ethereum accounts. */
-  recentTransfers: DisplayOpEvent[];
+  recentTransfers: TransferClog[];
   /** Names for each Daimo account we've interacted with. */
   namedAccounts: EAccount[];
   /** P-256 keys authorised by the Daimo account, in DER format */

--- a/apps/daimo-mobile/src/storage/storedTypeMigrations.ts
+++ b/apps/daimo-mobile/src/storage/storedTypeMigrations.ts
@@ -1,9 +1,4 @@
-import {
-  BigIntStr,
-  DisplayOpEvent,
-  OpStatus,
-  ProposedSwap,
-} from "@daimo/common";
+import { BigIntStr, OpStatus, ProposedSwap } from "@daimo/common";
 import { Address, Hex } from "viem";
 
 import {
@@ -71,25 +66,25 @@ interface StoredV15ForeignCoin {
   address?: Address;
 }
 
-export function migrateV15Clog(clog: StoredV15Clog): DisplayOpEvent {
+export function migrateV15Clog(clog: StoredV15Clog): StoredV16Clog {
   if (clog.type === "transfer" && clog.preSwapTransfer) {
     const { coin } = clog.preSwapTransfer;
     const tokenAddress = coin.address || coin.token;
     if (tokenAddress == null) {
-      return { ...clog, preSwapTransfer: undefined };
+      return { ...clog };
     }
+    // if preSwapTransfer is present for V15, the clog is an inbound swapClog.
     return {
       ...clog,
-      preSwapTransfer: {
-        ...clog.preSwapTransfer,
-        coin: {
-          token: tokenAddress,
-          chainId: coin.chainId,
-          decimals: coin.decimals,
-          name: coin.name,
-          symbol: coin.symbol,
-          logoURI: coin.logoURI,
-        },
+      type: "inboundSwap",
+      amountOther: clog.preSwapTransfer.amount,
+      coinOther: {
+        token: tokenAddress,
+        chainId: coin.chainId,
+        decimals: coin.decimals,
+        name: coin.name,
+        symbol: coin.symbol,
+        logoURI: coin.logoURI,
       },
     };
   } else {

--- a/apps/daimo-mobile/src/storage/storedTypes.ts
+++ b/apps/daimo-mobile/src/storage/storedTypes.ts
@@ -16,9 +16,32 @@ import { Address, Hex } from "viem";
 // This file contains current types. For old versions, see storedTypeMigrations.
 //
 
-export type StoredV16Clog = StoredV16TransferClog | StoredV15PaymentLinkClog;
+export type StoredV16Clog =
+  | StoredV16SimpleTransferClog
+  | StoredV15PaymentLinkClog
+  | StoredV16SwapClog;
 
-interface StoredV16TransferClog {
+interface StoredV16SwapClog {
+  timestamp: number;
+  status: OpStatus;
+  opHash?: Hex;
+  txHash?: Hex;
+  blockNumber?: number;
+  blockHash?: string;
+  logIndex?: number;
+  feeAmount?: number;
+  type: "inboundSwap" | "outboundSwap";
+  from: Address;
+  to: Address;
+  amount: number;
+  nonceMetadata?: Hex;
+  requestStatus?: StoredV15DaimoRequestV2Status;
+  memo?: string;
+  coinOther: StoredV16ForeignCoin;
+  amountOther: BigIntStr;
+}
+
+interface StoredV16SimpleTransferClog {
   timestamp: number;
   status: OpStatus;
   opHash?: Hex;
@@ -34,11 +57,6 @@ interface StoredV16TransferClog {
   nonceMetadata?: Hex;
   requestStatus?: StoredV15DaimoRequestV2Status;
   memo?: string;
-  preSwapTransfer?: {
-    coin: StoredV16ForeignCoin;
-    amount: BigIntStr;
-    from: Address;
-  };
 }
 
 export interface StoredV15PaymentLinkClog {

--- a/apps/daimo-mobile/src/sync/sync.ts
+++ b/apps/daimo-mobile/src/sync/sync.ts
@@ -1,6 +1,6 @@
 import { AccountHistoryResult } from "@daimo/api";
 import {
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   OpStatus,
   PendingOpEvent,
@@ -294,8 +294,8 @@ function applySync(
 
 export function syncFindSameOp(
   id: PendingOpEvent,
-  ops: DisplayOpEvent[]
-): DisplayOpEvent | null {
+  ops: TransferClog[]
+): TransferClog | null {
   return (
     ops.find(
       (r) =>
@@ -325,9 +325,9 @@ function addNamedAccounts(old: EAccount[], found: EAccount[]): EAccount[] {
 
 /** Add transfers based on new Transfer event logs */
 function addTransfers(
-  old: DisplayOpEvent[],
-  logs: DisplayOpEvent[]
-): DisplayOpEvent[] {
+  old: TransferClog[],
+  logs: TransferClog[]
+): TransferClog[] {
   // Sort new logs
   logs.sort((a, b) => {
     if (a.blockNumber !== b.blockNumber) return a.blockNumber! - b.blockNumber!;

--- a/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
@@ -1,6 +1,6 @@
 import {
   AddrLabel,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   OpStatus,
   assert,
@@ -47,7 +47,7 @@ interface HeaderObject {
 interface DisplayOpRenderObject {
   isHeader: false;
   id: string;
-  op: DisplayOpEvent;
+  op: TransferClog;
 }
 
 export function HistoryListSwipe({
@@ -89,7 +89,7 @@ export function HistoryListSwipe({
     );
   }
 
-  const renderRow = (t: DisplayOpEvent) => (
+  const renderRow = (t: TransferClog) => (
     <DisplayOpRow
       key={getDisplayOpId(t)}
       displayOp={t}
@@ -178,7 +178,7 @@ function DisplayOpRow({
   linkTo,
   showDate,
 }: {
-  displayOp: DisplayOpEvent;
+  displayOp: TransferClog;
   account: Account;
   linkTo: "op" | "account";
   showDate?: boolean;
@@ -317,7 +317,7 @@ function TransferAmountDate({
   );
 }
 
-function getDisplayOpId(t: DisplayOpEvent): string {
+function getDisplayOpId(t: TransferClog): string {
   return `${t.timestamp}-${t.from}-${t.to}-${t.txHash}-${t.opHash}`;
 }
 

--- a/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
@@ -45,7 +45,7 @@ interface HeaderObject {
   id: string;
   month: string;
 }
-interface DisplayOpRenderObject {
+interface displayClogRenderObject {
   isHeader: false;
   id: string;
   op: TransferClog;
@@ -91,9 +91,9 @@ export function HistoryListSwipe({
   }
 
   const renderRow = (t: TransferClog) => (
-    <DisplayOpRow
-      key={getDisplayOpId(t)}
-      displayOp={t}
+    <DisplayClogRow
+      key={getdisplayClogId(t)}
+      displayClog={t}
       account={account}
       {...{ linkTo, showDate }}
     />
@@ -113,7 +113,7 @@ export function HistoryListSwipe({
 
   // Full case: show a scrollable, lazy-loaded FlatList
   const stickyIndices = [] as number[];
-  const rows: (DisplayOpRenderObject | HeaderObject)[] = [];
+  const rows: (displayClogRenderObject | HeaderObject)[] = [];
 
   // Render a HeaderRow for each month, and make it sticky
   let lastMonth = "";
@@ -133,7 +133,7 @@ export function HistoryListSwipe({
     }
     rows.push({
       isHeader: false,
-      id: getDisplayOpId(op),
+      id: getdisplayClogId(op),
       op,
     });
   }
@@ -151,8 +151,8 @@ export function HistoryListSwipe({
           return <HeaderRow key={item.month} title={item.month} />;
         }
         return (
-          <DisplayOpRow
-            displayOp={item.op}
+          <DisplayClogRow
+            displayClog={item.op}
             account={account}
             showDate
             {...{ linkTo }}
@@ -173,34 +173,35 @@ function HeaderRow({ title }: { title: string }) {
   );
 }
 
-function DisplayOpRow({
-  displayOp,
+function DisplayClogRow({
+  displayClog,
   account,
   linkTo,
   showDate,
 }: {
-  displayOp: TransferClog;
+  displayClog: TransferClog;
   account: Account;
   linkTo: "op" | "account";
   showDate?: boolean;
 }) {
   const address = account.address;
 
-  assert(displayOp.amount > 0);
-  const [from, to] = getDisplayFromTo(displayOp);
+  assert(displayClog.amount > 0);
+  const [from, to] = getDisplayFromTo(displayClog);
   assert([from, to].includes(getAddress(address)));
   const setBottomSheetDetailHeight = useContext(SetBottomSheetDetailHeight);
 
   const otherAddr = from === address ? to : from;
   const otherAcc = getCachedEAccount(otherAddr);
-  const amountDelta = from === address ? -displayOp.amount : displayOp.amount;
+  const amountDelta =
+    from === address ? -displayClog.amount : displayClog.amount;
 
   const nav = useNav();
   const viewOp = () => {
-    const height = displayOp.type === "createLink" ? 490 : 440;
+    const height = displayClog.type === "createLink" ? 490 : 440;
     setBottomSheetDetailHeight(height);
     (nav as any).navigate("BottomSheetHistoryOp", {
-      op: displayOp,
+      op: displayClog,
       shouldAddInset: false,
     });
   };
@@ -209,23 +210,23 @@ function DisplayOpRow({
     else viewOp();
   };
 
-  const isPending = displayOp.status === OpStatus.pending;
+  const isPending = displayClog.status === OpStatus.pending;
   const textCol = isPending ? color.gray3 : color.midnight;
 
   // Title = counterparty name
   let opTitle = getAccountName(otherAcc);
   if (
     opTitle === AddrLabel.PaymentLink &&
-    displayOp.type === "claimLink" &&
-    displayOp.noteStatus.sender.addr === address &&
-    displayOp.noteStatus.claimer?.addr === address
+    displayClog.type === "claimLink" &&
+    displayClog.noteStatus.sender.addr === address &&
+    displayClog.noteStatus.claimer?.addr === address
   ) {
     // Special case: we cancelled our own payment link
     opTitle = "cancelled link";
   }
 
   const opMemo = getSynthesizedMemo(
-    displayOp,
+    displayClog,
     env(daimoChainFromId(account.homeChainId)).chainConfig,
     true
   );
@@ -236,9 +237,9 @@ function DisplayOpRow({
       <TouchableHighlight
         onPress={viewOp}
         {...touchHighlightUnderlay.subtle}
-        style={styles.displayOpRowWrap}
+        style={styles.displayClogRowWrap}
       >
-        <View style={styles.displayOpRow}>
+        <View style={styles.displayClogRow}>
           <View style={styles.transferOtherAccount}>
             <TouchableOpacity
               onPress={viewAccount}
@@ -265,7 +266,7 @@ function DisplayOpRow({
           </View>
           <TransferAmountDate
             amount={amountDelta}
-            timestamp={displayOp.timestamp}
+            timestamp={displayClog.timestamp}
             showDate={showDate}
             {...{ isPending }}
           />
@@ -318,7 +319,7 @@ function TransferAmountDate({
   );
 }
 
-function getDisplayOpId(t: TransferClog): string {
+function getdisplayClogId(t: TransferClog): string {
   return `${t.timestamp}-${t.from}-${t.to}-${t.txHash}-${t.opHash}`;
 }
 
@@ -339,10 +340,10 @@ const styles = StyleSheet.create({
     borderColor: color.grayLight,
     backgroundColor: "white",
   },
-  displayOpRowWrap: {
+  displayClogRowWrap: {
     marginHorizontal: -24,
   },
-  displayOpRow: {
+  displayClogRow: {
     paddingHorizontal: 24,
     paddingVertical: 16,
     flexDirection: "row",

--- a/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
@@ -20,6 +20,7 @@ import {
   TouchableOpacity,
 } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { getAddress } from "viem";
 
 import { SetBottomSheetDetailHeight } from "./HistoryOpScreen";
 import { navToAccountPage, useNav } from "../../../common/nav";
@@ -187,7 +188,7 @@ function DisplayOpRow({
 
   assert(displayOp.amount > 0);
   const [from, to] = getDisplayFromTo(displayOp);
-  assert([from, to].includes(address));
+  assert([from, to].includes(getAddress(address)));
   const setBottomSheetDetailHeight = useContext(SetBottomSheetDetailHeight);
 
   const otherAddr = from === address ? to : from;

--- a/apps/daimo-mobile/src/view/screen/history/HistoryOpScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/history/HistoryOpScreen.tsx
@@ -2,9 +2,9 @@ import {
   DaimoLinkNoteV2,
   DaimoNoteState,
   DaimoNoteStatus,
-  DisplayOpEvent,
+  TransferClog,
   OpStatus,
-  PaymentLinkOpEvent,
+  PaymentLinkClog,
   amountToDollars,
   getAccountName,
   getDisplayFromTo,
@@ -130,7 +130,7 @@ function NoteView({
   leaveScreen,
 }: {
   account: Account;
-  note: PaymentLinkOpEvent;
+  note: PaymentLinkClog;
   leaveScreen: () => void;
 }) {
   const daimoChain = daimoChainFromId(account.homeChainId);
@@ -165,7 +165,7 @@ function LinkToExplorer({
   op,
 }: {
   chainConfig: ChainConfig;
-  op: DisplayOpEvent;
+  op: TransferClog;
 }) {
   // Ethreceipts
   const chainId = chainConfig.chainL2.id;
@@ -177,13 +177,7 @@ function LinkToExplorer({
   return <ButtonBig onPress={openURL} type="subtle" title="VIEW RECEIPT" />;
 }
 
-function TransferBody({
-  account,
-  op,
-}: {
-  account: Account;
-  op: DisplayOpEvent;
-}) {
+function TransferBody({ account, op }: { account: Account; op: TransferClog }) {
   const nav = useNav();
 
   const sentByUs = op.from === account.address;
@@ -256,7 +250,7 @@ function TransferBody({
   );
 }
 
-function getOpVerb(op: DisplayOpEvent, accountAddress: Address) {
+function getOpVerb(op: TransferClog, accountAddress: Address) {
   const isPayLink = op.type === "createLink" || op.type === "claimLink";
   const sentByUs = op.from === accountAddress;
   const isRequestResponse = op.type === "transfer" && op.requestStatus != null;

--- a/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
@@ -51,16 +51,12 @@ export function SwapBottomSheet({ swap }: { swap: ProposedSwap }) {
       });
     },
     pendingOp: {
-      type: "transfer",
+      type: "outboundSwap",
       from: swap.fromAcc.addr,
       to: account!.address,
       amount: swap.toAmount,
-      preSwapTransfer: {
-        // TODO:
-        coin: swap.fromCoin,
-        from: swap.fromAcc.addr,
-        amount: swap.fromAmount,
-      },
+      coinOther: swap.fromCoin,
+      amountOther: swap.fromAmount,
       status: OpStatus.pending,
       timestamp: now(),
     },

--- a/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
@@ -56,6 +56,7 @@ export function SwapBottomSheet({ swap }: { swap: ProposedSwap }) {
       to: account!.address,
       amount: swap.toAmount,
       preSwapTransfer: {
+        // TODO:
         coin: swap.fromCoin,
         from: swap.fromAcc.addr,
         amount: swap.fromAmount,

--- a/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/SwapBottomSheet.tsx
@@ -29,7 +29,7 @@ import Spacer from "../shared/Spacer";
 import { color, ss } from "../shared/style";
 import { TextBodyCaps, TextH3 } from "../shared/text";
 
-// Bottom sheet for proposed swap
+// Bottom sheet for proposed inbound swap
 export function SwapBottomSheet({ swap }: { swap: ProposedSwap }) {
   const account = useAccount();
   const nav = useNav();
@@ -51,7 +51,7 @@ export function SwapBottomSheet({ swap }: { swap: ProposedSwap }) {
       });
     },
     pendingOp: {
-      type: "outboundSwap",
+      type: "inboundSwap",
       from: swap.fromAcc.addr,
       to: account!.address,
       amount: swap.toAmount,

--- a/apps/scratchpad/src/index.ts
+++ b/apps/scratchpad/src/index.ts
@@ -5,6 +5,7 @@ import { NameRegistry } from "@daimo/api/src/contract/nameRegistry";
 import { NoteIndexer } from "@daimo/api/src/contract/noteIndexer";
 import { OpIndexer } from "@daimo/api/src/contract/opIndexer";
 import { RequestIndexer } from "@daimo/api/src/contract/requestIndexer";
+import { SwapClogMatcher } from "@daimo/api/src/contract/SwapClogMatcher";
 import { DB } from "@daimo/api/src/db/db";
 import { StubExternalApiCache } from "@daimo/api/src/db/externalApiCache";
 import { getViemClientFromEnv } from "@daimo/api/src/network/viemClient";
@@ -87,7 +88,8 @@ async function metrics() {
   const paymentMemoTracker = new PaymentMemoTracker(db);
   const tokenReg = new TokenRegistry();
 
-  const opIndexer = new OpIndexer();
+  const swapClogMatcher = new SwapClogMatcher(tokenReg);
+  const opIndexer = new OpIndexer(swapClogMatcher);
   const noteIndexer = new NoteIndexer(nameReg, opIndexer, paymentMemoTracker);
   const requestIndexer = new RequestIndexer(db, nameReg, paymentMemoTracker);
   const foreignCoinIndexer = new ForeignCoinIndexer(nameReg, vc, tokenReg);
@@ -97,7 +99,8 @@ async function metrics() {
     noteIndexer,
     requestIndexer,
     foreignCoinIndexer,
-    paymentMemoTracker
+    paymentMemoTracker,
+    swapClogMatcher
   );
 
   console.log(`[METRICS] using ${vc.publicClient.chain.name}`);

--- a/packages/daimo-api/src/api/deployWallet.ts
+++ b/packages/daimo-api/src/api/deployWallet.ts
@@ -1,7 +1,7 @@
 import {
   DaimoAccountCall,
   DaimoLinkStatus,
-  TransferOpEvent,
+  SimpleTransferClog,
   formatDaimoLink,
   getInviteStatus,
 } from "@daimo/common";
@@ -33,7 +33,7 @@ export async function deployWallet(
   telemetry: Telemetry,
   paymaster: Paymaster,
   inviteGraph: InviteGraph
-): Promise<{ address: Address; faucetTransfer?: TransferOpEvent }> {
+): Promise<{ address: Address; faucetTransfer?: SimpleTransferClog }> {
   // For now, invite is required
   const inviteStatus = getInviteStatus(inviteLinkStatus);
 
@@ -97,7 +97,7 @@ export async function deployWallet(
 
   // Send starter USDC only for invite links, and check for spam.
   let sendFaucet = false;
-  let faucetTransfer: TransferOpEvent | undefined;
+  let faucetTransfer: SimpleTransferClog | undefined;
   if (inviteLinkStatus.link.type === "invite") {
     const { requestInfo } = ctx;
     const isTestnet = chainConfig.chainL2.testnet;

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -58,7 +58,7 @@ export interface AccountHistoryResult {
   chainGasConstants: ChainGasConstants;
   recommendedExchanges: RecommendedExchange[];
 
-  transferLogs: TransferClog[];
+  transferLogs: TransferClog[]; // TODO: rename to transferClogs
   namedAccounts: EAccount[];
   accountKeys: KeyData[];
   linkedAccounts: LinkedAccount[];
@@ -129,15 +129,15 @@ export async function getAccountHistory(
   // TODO: get userops, including reverted ones. Show failed sends.
 
   // Get successful transfers since sinceBlockNum
-  const transferLogs = homeCoinIndexer.filterTransfers({
+  const transferClogs = homeCoinIndexer.filterTransfers({
     addr: address,
     sinceBlockNum: BigInt(sinceBlockNum),
   });
   let elapsedMs = performance.now() - startMs;
-  console.log(`${log}: ${elapsedMs}ms ${transferLogs.length} logs`);
+  console.log(`${log}: ${elapsedMs}ms ${transferClogs.length} logs`);
 
   // Get named accounts
-  const namedAccounts = await getNamedAccountsFromClogs(transferLogs, nameReg);
+  const namedAccounts = await getNamedAccountsFromClogs(transferClogs, nameReg);
 
   // Get account keys
   const accountKeys = keyReg.resolveAddressKeys(address);
@@ -208,7 +208,7 @@ export async function getAccountHistory(
     recommendedExchanges,
     suggestedActions: [],
 
-    transferLogs,
+    transferLogs: transferClogs,
     namedAccounts,
     accountKeys,
     linkedAccounts,
@@ -242,8 +242,6 @@ async function getNamedAccountsFromClogs(
     if (clog.type === "claimLink" || clog.type === "createLink") {
       if (clog.noteStatus.claimer) addrs.add(clog.noteStatus.claimer.addr);
       addrs.add(clog.noteStatus.sender.addr);
-    } else if (clog.type === "transfer" && clog.preSwapTransfer) {
-      addrs.add(clog.preSwapTransfer.from);
     }
   });
   const namedAccounts = (

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -5,7 +5,7 @@ import {
   CurrencyExchangeRate,
   DaimoInviteCodeStatus,
   DaimoRequestV2Status,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   KeyData,
   LinkedAccount,
@@ -58,7 +58,7 @@ export interface AccountHistoryResult {
   chainGasConstants: ChainGasConstants;
   recommendedExchanges: RecommendedExchange[];
 
-  transferLogs: DisplayOpEvent[];
+  transferLogs: TransferClog[];
   namedAccounts: EAccount[];
   accountKeys: KeyData[];
   linkedAccounts: LinkedAccount[];
@@ -232,7 +232,7 @@ export async function getAccountHistory(
 }
 
 async function getNamedAccountsFromClogs(
-  clogs: DisplayOpEvent[],
+  clogs: TransferClog[],
   nameReg: NameRegistry
 ): Promise<EAccount[]> {
   const addrs = new Set<Address>();

--- a/packages/daimo-api/src/contract/SwapClogMatcher.ts
+++ b/packages/daimo-api/src/contract/SwapClogMatcher.ts
@@ -33,10 +33,10 @@ export class SwapClogMatcher {
     const result = await retryBackoff(
       `swapClogMatcher-logs-query-${from}-${to}`,
       async () => {
-        return await pg.query(
+        return pg.query(
           `SELECT * from erc20_transfers WHERE 
           tx_hash = ANY($1::bytea[]);`,
-          [txHashes as any]
+          [txHashes]
         );
       }
     );

--- a/packages/daimo-api/src/contract/SwapClogMatcher.ts
+++ b/packages/daimo-api/src/contract/SwapClogMatcher.ts
@@ -34,7 +34,7 @@ export class SwapClogMatcher {
       `swapClogMatcher-logs-query-${from}-${to}`,
       async () => {
         return await pg.query(
-          `SELECT * from erc20_transfers 
+          `SELECT * from erc20_transfers WHERE 
           tx_hash = ANY($1::bytea[]);`,
           [txHashes as any]
         );

--- a/packages/daimo-api/src/contract/SwapClogMatcher.ts
+++ b/packages/daimo-api/src/contract/SwapClogMatcher.ts
@@ -1,0 +1,113 @@
+import { Pool } from "pg";
+import { Address, bytesToHex, getAddress } from "viem";
+
+import { ForeignTokenTransfer } from "./foreignCoinIndexer";
+import { TokenRegistry } from "../server/tokenRegistry";
+import { retryBackoff } from "../utils/retryBackoff";
+
+export class SwapClogMatcher {
+  /** Map of transactionHash to transfers that are within that transaction */
+  private txHashToTransfers: Map<string, ForeignTokenTransfer[]> = new Map();
+
+  /** Map of starting "to" transfer to the corresponding "from" transfer */
+  private correspondingSwapTransfers: Map<
+    ForeignTokenTransfer,
+    ForeignTokenTransfer
+  > = new Map();
+
+  constructor(private tokenReg: TokenRegistry) {}
+
+  // Given a set transaction hashes, load any transfers that are associated
+  // with those transactions.
+  async loadSwapTransfers(
+    pg: Pool,
+    from: number,
+    to: number,
+    chainId: number,
+    transactionHashes: string[]
+  ) {
+    const startTime = Date.now();
+
+    const txHashes = transactionHashes.map((tx) => `\\x${tx.substring(2)}`);
+
+    const result = await retryBackoff(
+      `swapClogMatcher-logs-query-${from}-${to}`,
+      async () => {
+        return await pg.query(
+          `SELECT * from erc20_transfers 
+          tx_hash = ANY($1::bytea[]);`,
+          [txHashes as any]
+        );
+      }
+    );
+
+    for (const row of result.rows) {
+      const log = {
+        blockHash: bytesToHex(row.block_hash, { size: 32 }),
+        blockNumber: BigInt(row.block_num),
+        transactionHash: bytesToHex(row.tx_hash, { size: 32 }),
+        transactionIndex: row.tx_idx,
+        logIndex: row.log_idx,
+        address: getAddress(bytesToHex(row.log_addr, { size: 20 })),
+        from: getAddress(bytesToHex(row.f, { size: 20 })),
+        to: getAddress(bytesToHex(row.t, { size: 20 })),
+        value: BigInt(row.v),
+      };
+      const token = this.tokenReg.getToken(log.address, chainId, true); // include home coin
+      if (token == null) continue;
+
+      const foreignTransfer: ForeignTokenTransfer = {
+        ...log,
+        foreignToken: token,
+      };
+      this.txHashToTransfers.set(foreignTransfer.transactionHash, [
+        ...(this.txHashToTransfers.get(foreignTransfer.transactionHash) || []),
+        foreignTransfer,
+      ]);
+    }
+    console.log(
+      `[SWAP] loaded ${result.rows.length} bundled transfers in ${
+        Date.now() - startTime
+      }ms`
+    );
+  }
+
+  // For a SwapClog, find the corresponding "to" transfer given the "from"
+  // transfer (from a Daimo account to a foreign account).
+  getMatchingSwapTransfer(from: Address, transactionHash: string) {
+    const transfers = this.txHashToTransfers.get(transactionHash);
+    if (!transfers || transfers.length === 0) return null;
+
+    // Get the corresponding transfer to the given logIndex transfer.
+    let currentTransfer = transfers.find((t) => t.from === from);
+    if (!currentTransfer) return null;
+    const startTransfer = currentTransfer;
+
+    const visited = new Set();
+    visited.add(startTransfer.logIndex);
+
+    // Follow the chain of transfers to find the end of the cycle.
+    while (true) {
+      const nextTransfer = transfers.find(
+        (t) => t.from === currentTransfer!.to && !visited.has(t.logIndex)
+      );
+
+      if (!nextTransfer) break;
+
+      visited.add(nextTransfer.logIndex);
+      currentTransfer = nextTransfer;
+    }
+
+    // Only create a corresponding swap transfer if the endpoint transfers
+    // are different coins.
+    if (currentTransfer.address === startTransfer.address) return null;
+
+    this.correspondingSwapTransfers.set(startTransfer, currentTransfer);
+    console.log(
+      `[SWAP] matched ${JSON.stringify(startTransfer)} to ${JSON.stringify(
+        currentTransfer
+      )}`
+    );
+    return currentTransfer;
+  }
+}

--- a/packages/daimo-api/src/contract/foreignCoinIndexer.ts
+++ b/packages/daimo-api/src/contract/foreignCoinIndexer.ts
@@ -220,12 +220,13 @@ export class ForeignCoinIndexer extends Indexer {
   ): Promise<ProposedSwap | null> {
     const swap = await retryBackoff(`getProposedSwapForLog`, async () => {
       const fromAcc = await this.nameReg.getEAccount(log.from);
+      const homeCoin = baseUSDC;
 
       return this.getProposedSwap(
         log.foreignToken.token,
         log.value.toString() as `${bigint}`,
         fromAcc,
-        baseUSDC.token, // USDC
+        homeCoin.token, // TODO: retrieve correct home coin address
         log.to
       );
     });

--- a/packages/daimo-api/src/contract/homeCoinIndexer.ts
+++ b/packages/daimo-api/src/contract/homeCoinIndexer.ts
@@ -240,6 +240,7 @@ export class HomeCoinIndexer extends Indexer {
           amountOther: `${correspondingForeignSend.value}` as `${bigint}`,
         }
       : undefined;
+
     // Foreign receive and foreign send are mutually exclusive.
     const outboundTo = correspondingForeignReceive
       ? null

--- a/packages/daimo-api/src/offchain/inviteCodeTracker.ts
+++ b/packages/daimo-api/src/offchain/inviteCodeTracker.ts
@@ -2,7 +2,7 @@ import {
   DaimoInviteCodeStatus,
   DaimoLinkInviteCode,
   OpStatus,
-  TransferOpEvent,
+  SimpleTransferClog,
   dollarsToAmount,
   formatDaimoLink,
   now,
@@ -36,7 +36,7 @@ export class InviteCodeTracker {
     invitee: Address,
     code: InviteCodeRow,
     deviceAttestationString: Hex
-  ): Promise<TransferOpEvent | undefined> {
+  ): Promise<SimpleTransferClog | undefined> {
     const isFaucetAttestationUsed = await this.db.isFaucetAttestationUsed(
       deviceAttestationString
     );
@@ -53,7 +53,7 @@ export class InviteCodeTracker {
     }
 
     // Try sending bonus
-    let faucetTransfer: TransferOpEvent | undefined;
+    let faucetTransfer: SimpleTransferClog | undefined;
     if (code.bonusDollarsInvitee > 0) {
       console.log(
         `[INVITE] sending faucet to invitee ${invitee} ${code.bonusDollarsInvitee}`
@@ -105,7 +105,7 @@ export class InviteCodeTracker {
     deviceAttestationString: Hex,
     invCode: string,
     maybeSendFaucet: boolean
-  ): Promise<{ isValid: boolean; faucetTransfer?: TransferOpEvent }> {
+  ): Promise<{ isValid: boolean; faucetTransfer?: SimpleTransferClog }> {
     await retryBackoff(`incrementInviteCodeUseCount`, () =>
       this.db.incrementInviteCodeUseCount(invCode)
     );

--- a/packages/daimo-api/src/server/cron.ts
+++ b/packages/daimo-api/src/server/cron.ts
@@ -1,6 +1,6 @@
 import {
-  DisplayOpEvent,
   EAccount,
+  TransferClog,
   amountToDollars,
   formatDaimoLink,
   getAccountName,
@@ -159,7 +159,7 @@ export class Crontab {
     }
   };
 
-  async postRecentTransfer(opEvent: DisplayOpEvent) {
+  async postRecentTransfer(opEvent: TransferClog) {
     const fromName = this.nameRegistry.resolveDaimoNameForAddr(opEvent.from);
     const toName = this.nameRegistry.resolveDaimoNameForAddr(opEvent.to);
 

--- a/packages/daimo-api/src/server/pushNotifier.ts
+++ b/packages/daimo-api/src/server/pushNotifier.ts
@@ -4,7 +4,7 @@ import {
   DaimoNoteStatus,
   DaimoRequestState,
   DaimoRequestV2Status,
-  DisplayOpEvent,
+  TransferClog,
   amountToDollars,
   assert,
   assertNotNull,
@@ -237,7 +237,7 @@ export class PushNotifier {
     addr: Address,
     other: Address,
     amount: number,
-    opEvent: DisplayOpEvent
+    opEvent: TransferClog
   ): Promise<ExpoPushMessage[]> {
     if (opEvent.type !== "transfer") return []; // Only transfer opEvents handled here
 

--- a/packages/daimo-api/src/server/server.ts
+++ b/packages/daimo-api/src/server/server.ts
@@ -22,6 +22,7 @@ import { NoteIndexer } from "../contract/noteIndexer";
 import { OpIndexer } from "../contract/opIndexer";
 import { Paymaster } from "../contract/paymaster";
 import { RequestIndexer } from "../contract/requestIndexer";
+import { SwapClogMatcher } from "../contract/SwapClogMatcher";
 import { DB } from "../db/db";
 import { ExternalApiCache } from "../db/externalApiCache";
 import { chainConfig, getEnvApi } from "../env";
@@ -69,17 +70,20 @@ async function main() {
   const tokenReg = new TokenRegistry();
   await tokenReg.load();
 
-  const opIndexer = new OpIndexer();
+  const swapClogMatcher = new SwapClogMatcher(tokenReg);
+  const opIndexer = new OpIndexer(swapClogMatcher);
   const noteIndexer = new NoteIndexer(nameReg, opIndexer, paymentMemoTracker);
   const requestIndexer = new RequestIndexer(db, nameReg, paymentMemoTracker);
   const foreignCoinIndexer = new ForeignCoinIndexer(nameReg, vc, tokenReg);
+
   const homeCoinIndexer = new HomeCoinIndexer(
     vc,
     opIndexer,
     noteIndexer,
     requestIndexer,
     foreignCoinIndexer,
-    paymentMemoTracker
+    paymentMemoTracker,
+    swapClogMatcher
   );
 
   const bundlerClient = getBundlerClientFromEnv(opIndexer);

--- a/packages/daimo-api/src/server/tokenRegistry.ts
+++ b/packages/daimo-api/src/server/tokenRegistry.ts
@@ -1,9 +1,10 @@
 import {
   ForeignToken,
-  assert,
-  baseUSDC,
   baseUSDbC,
+  assert,
   getChainName,
+  getSupportedHomeCoinByAddress,
+  baseUSDC,
   getNativeETHForChain,
 } from "@daimo/common";
 import { Address, Hex, getAddress, isAddress } from "viem";
@@ -90,15 +91,26 @@ export class TokenRegistry {
   }
 
   // Get a token from the foreign token list.
-  public getToken(addr: Address, chainId?: number): ForeignToken | undefined {
+  // If includeHomeCoin is true, include the home coin in the list.
+  public getToken(
+    addr: Address,
+    chainId?: number,
+    includeHomeCoin?: boolean
+  ): ForeignToken | undefined {
     const tokenAddress = getAddress(addr);
 
-    const token = this.foreignTokensByChain
+    let token = this.foreignTokensByChain
       .get(chainId ?? this.defaultChainId)
       ?.get(tokenAddress);
-    console.log(
-      `[TOKEN-REG] retrieved token ${token?.symbol} for addr ${addr}`
-    );
+
+    // If not a foreign token, check if it's a home token.
+    if (includeHomeCoin && !token) {
+      token = getSupportedHomeCoinByAddress(tokenAddress);
+    }
+
+    if (!token)
+      console.log(`[TOKEN-REG] could not retrieve token for addr ${addr}`);
+
     return token;
   }
 

--- a/packages/daimo-api/test/dtest.ts
+++ b/packages/daimo-api/test/dtest.ts
@@ -5,6 +5,7 @@ import { NameRegistry } from "../src/contract/nameRegistry";
 import { NoteIndexer } from "../src/contract/noteIndexer";
 import { OpIndexer } from "../src/contract/opIndexer";
 import { RequestIndexer } from "../src/contract/requestIndexer";
+import { SwapClogMatcher } from "../src/contract/SwapClogMatcher";
 import { StubExternalApiCache } from "../src/db/externalApiCache";
 import { getViemClientFromEnv } from "../src/network/viemClient";
 import { PaymentMemoTracker } from "../src/offchain/paymentMemoTracker";
@@ -24,14 +25,15 @@ export async function main() {
   );
   const paymentMemoTracker = new PaymentMemoTracker(null as any);
 
-  const opIndexer = new OpIndexer();
+  const tokenReg = new TokenRegistry();
+  const swapClogMatcher = new SwapClogMatcher(tokenReg);
+  const opIndexer = new OpIndexer(swapClogMatcher);
   const noteIndexer = new NoteIndexer(nameReg, opIndexer, paymentMemoTracker);
   const requestIndexer = new RequestIndexer(
     null as any,
     nameReg,
     paymentMemoTracker
   );
-  const tokenReg = new TokenRegistry();
   const foreignCoinIndexer = new ForeignCoinIndexer(nameReg, vc, tokenReg);
   const coinIndexer = new HomeCoinIndexer(
     vc,
@@ -39,7 +41,8 @@ export async function main() {
     noteIndexer,
     requestIndexer,
     foreignCoinIndexer,
-    paymentMemoTracker
+    paymentMemoTracker,
+    swapClogMatcher
   );
   const keyReg = new KeyRegistry();
 

--- a/packages/daimo-api/test/pushNotifier.test.ts
+++ b/packages/daimo-api/test/pushNotifier.test.ts
@@ -4,7 +4,7 @@ import {
   DaimoNoteStatus,
   DaimoRequestState,
   DaimoRequestV2Status,
-  DisplayOpEvent,
+  TransferClog,
   EAccount,
   ForeignToken,
   OpStatus,
@@ -341,8 +341,8 @@ function createNotifierAliceBob() {
   } as unknown as KeyRegistry;
 
   const stubCoinIndexer = {
-    attachTransferOpProperties: (log: Transfer): DisplayOpEvent => {
-      const op: DisplayOpEvent = {
+    attachTransferOpProperties: (log: Transfer): TransferClog => {
+      const op: TransferClog = {
         type: "transfer",
         status: OpStatus.confirmed,
         timestamp: guessTimestampFromNum(

--- a/packages/daimo-common/src/foreignToken.ts
+++ b/packages/daimo-common/src/foreignToken.ts
@@ -1,5 +1,5 @@
 import { ChainConfig } from "@daimo/contract";
-import { Address, formatUnits, zeroAddress } from "viem";
+import { Address, formatUnits, getAddress, zeroAddress } from "viem";
 
 /**
  * USDC token addresses taken from:
@@ -49,7 +49,7 @@ export enum TokenLogo {
 //
 
 export const baseSepoliaWETH: ForeignToken = {
-  token: "0x4200000000000000000000000000000000000006",
+  token: getAddress("0x4200000000000000000000000000000000000006"),
   decimals: 18,
   name: "Ethereum",
   symbol: "WETH",
@@ -58,7 +58,7 @@ export const baseSepoliaWETH: ForeignToken = {
 };
 
 export const baseSepoliaUSDC: ForeignToken = {
-  token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  token: getAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -71,7 +71,7 @@ export const baseSepoliaUSDC: ForeignToken = {
 //
 
 export const baseWETH: ForeignToken = {
-  token: "0x4200000000000000000000000000000000000006",
+  token: getAddress("0x4200000000000000000000000000000000000006"),
   decimals: 18,
   name: "Ethereum",
   symbol: "WETH",
@@ -80,7 +80,7 @@ export const baseWETH: ForeignToken = {
 };
 
 export const baseUSDC: ForeignToken = {
-  token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  token: getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
   name: "USD Coin",
   symbol: "USDC",
   decimals: 6,
@@ -89,7 +89,7 @@ export const baseUSDC: ForeignToken = {
 };
 
 export const baseUSDbC: ForeignToken = {
-  token: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
+  token: getAddress("0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA"),
   name: "Bridged USD Coin", // USDbC has a bad name & logo on CoinGecko
   symbol: "USDbC",
   decimals: 6,
@@ -98,7 +98,7 @@ export const baseUSDbC: ForeignToken = {
 };
 
 export const baseDAI: ForeignToken = {
-  token: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+  token: getAddress("0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"),
   name: "Dai Stablecoin",
   symbol: "DAI",
   decimals: 18,
@@ -107,7 +107,7 @@ export const baseDAI: ForeignToken = {
 };
 
 export const baseUSDT: ForeignToken = {
-  token: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2",
+  token: getAddress("0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"),
   name: "Tether USD",
   symbol: "USDT",
   decimals: 6,
@@ -120,7 +120,7 @@ export const baseUSDT: ForeignToken = {
 //
 
 export const arbitrumUSDC: ForeignToken = {
-  token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  token: getAddress("0xaf88d065e77c8cC2239327C5EDb3A432268e5831"),
   name: "USD Coin",
   symbol: "USDC",
   decimals: 6,
@@ -129,7 +129,7 @@ export const arbitrumUSDC: ForeignToken = {
 };
 
 export const arbitrumWETH: ForeignToken = {
-  token: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+  token: getAddress("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"),
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -142,7 +142,7 @@ export const arbitrumWETH: ForeignToken = {
 //
 
 export const arbitrumSepoliaUSDC: ForeignToken = {
-  token: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+  token: getAddress("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -151,7 +151,7 @@ export const arbitrumSepoliaUSDC: ForeignToken = {
 };
 
 export const arbitrumSepoliaWETH: ForeignToken = {
-  token: "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
+  token: getAddress("0x980B62Da83eFf3D4576C647993b0c1D7faf17c73"),
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -164,7 +164,7 @@ export const arbitrumSepoliaWETH: ForeignToken = {
 //
 
 export const optimismUSDC: ForeignToken = {
-  token: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+  token: getAddress("0x0b2c639c533813f4aa9d7837caf62653d097ff85"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -173,7 +173,7 @@ export const optimismUSDC: ForeignToken = {
 };
 
 export const optimismWETH: ForeignToken = {
-  token: "0x4200000000000000000000000000000000000006",
+  token: getAddress("0x4200000000000000000000000000000000000006"),
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -186,7 +186,7 @@ export const optimismWETH: ForeignToken = {
 //
 
 export const optimismSepoliaUSDC: ForeignToken = {
-  token: "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+  token: getAddress("0x5fd84259d66Cd46123540766Be93DFE6D43130D7"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -195,7 +195,7 @@ export const optimismSepoliaUSDC: ForeignToken = {
 };
 
 export const optimismSepoliaWETH: ForeignToken = {
-  token: "0x4200000000000000000000000000000000000006",
+  token: getAddress("0x4200000000000000000000000000000000000006"),
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -208,7 +208,7 @@ export const optimismSepoliaWETH: ForeignToken = {
 //
 
 export const polygonUSDC: ForeignToken = {
-  token: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+  token: getAddress("0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -217,7 +217,7 @@ export const polygonUSDC: ForeignToken = {
 };
 
 export const polygonWETH: ForeignToken = {
-  token: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+  token: getAddress("0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"),
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -230,7 +230,7 @@ export const polygonWETH: ForeignToken = {
 //
 
 export const polygonSepoliaUSDC: ForeignToken = {
-  token: "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
+  token: getAddress("0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -243,7 +243,7 @@ export const polygonSepoliaUSDC: ForeignToken = {
 //
 
 export const avalancheUSDC: ForeignToken = {
-  token: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+  token: getAddress("0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -252,7 +252,7 @@ export const avalancheUSDC: ForeignToken = {
 };
 
 export const avalancheWETH: ForeignToken = {
-  token: "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab", // WETH.e
+  token: getAddress("0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab"), // WETH.e
   decimals: 18,
   name: "Wrapped Ether",
   symbol: "WETH",
@@ -265,7 +265,7 @@ export const avalancheWETH: ForeignToken = {
 //
 
 export const avalancheFujiUSDC: ForeignToken = {
-  token: "0x5425890298aed601595a70ab815c96711a31bc65",
+  token: getAddress("0x5425890298aed601595a70ab815c96711a31bc65"),
   decimals: 6,
   name: "USD Coin",
   symbol: "USDC",
@@ -277,7 +277,8 @@ export const avalancheFujiUSDC: ForeignToken = {
 
 export function getForeignCoinDisplayAmount(
   amount: `${bigint}`,
-  coin: ForeignToken
+  coin: ForeignToken,
+  numDecimals?: number
 ) {
   const amountStr = formatUnits(BigInt(amount), coin.decimals);
   const maxDecimals = 6;
@@ -362,5 +363,15 @@ export const supportedSendCoins = new Map<string, ForeignToken>([
 export function getSupportedSendCoinByAddress(
   address: string
 ): ForeignToken | undefined {
-  return supportedSendCoins.get(address);
+  return supportedSendCoins.get(getAddress(address));
+}
+
+// Supported home coins.
+export const supportedHomeCoins: ForeignToken[] = [baseUSDC];
+
+// Retrieve home coin by address.
+export function getSupportedHomeCoinByAddress(
+  address: string
+): ForeignToken | undefined {
+  return supportedHomeCoins.find((coin) => coin.token === address);
 }

--- a/packages/daimo-common/src/op.ts
+++ b/packages/daimo-common/src/op.ts
@@ -238,21 +238,20 @@ export function getSynthesizedMemo(
   if (op.type === "transfer" && op.requestStatus) {
     return op.requestStatus.memo;
   } else if (op.type === "inboundSwap" || op.type === "outboundSwap") {
-    const isOutboundSwap = op.type === "inboundSwap";
     const otherCoin = op.coinOther;
     const readableAmount = getForeignCoinDisplayAmount(
       op.amountOther,
       otherCoin
     );
 
-    if (short) {
-      return isOutboundSwap
-        ? `${coinName} → ${readableAmount} ${otherCoin.symbol}`
-        : `${readableAmount} ${otherCoin.symbol} → ${coinName}`;
-    } else {
-      return isOutboundSwap
-        ? `Sent ${coinName} as ${readableAmount} ${otherCoin.symbol}`
+    if (op.type === "inboundSwap") {
+      return short
+        ? `${readableAmount} ${otherCoin.symbol} → ${coinName}`
         : `Accepted ${readableAmount} ${otherCoin.symbol} as ${coinName}`;
+    } else {
+      return short
+        ? `${coinName} → ${readableAmount} ${otherCoin.symbol}`
+        : `Sent ${coinName} as ${readableAmount} ${otherCoin.symbol}`;
     }
   }
 }

--- a/packages/daimo-common/src/op.ts
+++ b/packages/daimo-common/src/op.ts
@@ -1,9 +1,15 @@
-import { ChainConfig } from "@daimo/contract";
+import {
+  TransferClog,
+  getForeignCoinDisplayAmount,
+  isNativeETH,
+} from "@daimo/common";
+import { ChainConfig, DaimoChain } from "@daimo/contract";
 import { Address, Hex } from "viem";
 
 import { DaimoNoteStatus, DaimoRequestV2Status } from "./daimoLinkStatus";
 import { ForeignToken, getForeignCoinDisplayAmount } from "./foreignToken";
 import { BigIntStr } from "./model";
+import { env } from "../../../env";
 
 /**
  * An OpEvent is an onchain event affecting a Daimo account. Each OpEvent
@@ -21,9 +27,9 @@ import { BigIntStr } from "./model";
  * - Adding or removing a device (AddDevice / RemoveDevice log, userop)
  * - Creating or redeeming a Note (NoteCreated / NoteRedeemed log, userop)
  */
-export type OpEvent = TransferOpEvent | PaymentLinkOpEvent | KeyRotationOpEvent;
+export type OpEvent = TransferClog | KeyRotationOpEvent;
 
-export type DisplayOpEvent = TransferOpEvent | PaymentLinkOpEvent;
+export type TransferClog = SimpleTransferClog | PaymentLinkClog | SwapClog;
 
 /**
  *  Fetched data for a pending OpEvent. For a pending op, we (usually)
@@ -38,6 +44,11 @@ export type PendingOpEvent = {
   inviteCode?: string;
 };
 
+/*
+ * Deprecated usage in TransferClog.
+ *
+ * Use SwapClog instead for transfers that involve a swap on the same chain.
+ */
 export type PreSwapTransfer = {
   coin: ForeignToken;
   amount: BigIntStr; // in native unit of the token
@@ -45,7 +56,8 @@ export type PreSwapTransfer = {
 };
 
 /**
- * Represents a transfer of tokens from one address to another.
+ * Represents a transfer of the same tokens from one address to another on the
+ * same chain (a.k.a. same coins, same chain).
  *
  * There's a surprising amount of complexity to the state of a transfer.
  *
@@ -73,7 +85,7 @@ export type PreSwapTransfer = {
  * - For others, we show an address, except for a few special ones where we can
  *   show a descriptive slug like Daimo Faucet, Coinbase, or Binance.
  */
-export interface TransferOpEvent extends OpEventBase {
+export interface SimpleTransferClog extends OpEventBase {
   type: "transfer";
 
   from: Address;
@@ -92,10 +104,10 @@ export interface TransferOpEvent extends OpEventBase {
   memo?: string;
 
   /** If the transfer was caused by a user-initiated swap, the swap origin */
-  preSwapTransfer?: PreSwapTransfer;
+  preSwapTransfer?: PreSwapTransfer; // Keep for backwards compatibility (?)
 }
 
-export interface PaymentLinkOpEvent extends OpEventBase {
+export interface PaymentLinkClog extends OpEventBase {
   type: "createLink" | "claimLink";
 
   from: Address;
@@ -110,6 +122,36 @@ export interface PaymentLinkOpEvent extends OpEventBase {
   nonceMetadata?: Hex;
 
   /** Memo from the sender, if present */
+  memo?: string;
+}
+
+/**
+ * Represents a token swap between two accounts on the same chain.
+ * Same chain, different coins.
+ *
+ * A token swap can be inbound swap (e.g. a Daimo account receives a foreign
+ * token transfer in their inbox) or outbound swap (e.g. account Alice sends a
+ * foreign token transfer to Bob).
+ */
+export interface SwapClog extends OpEventBase {
+  type: "swap";
+
+  from: Address;
+  to: Address;
+
+  /** TODO: use bigint? Unnecessary for USDC. MAX_SAFE_INT = $9,007,199,254 */
+  amount: number; // amount that affects the user
+
+  /** "Other" coin involved in the swap (i.e. not homeCoin or bridgeCoin) */
+  coinOther: ForeignToken;
+
+  /** Amount of the coinOther in the swap (in native unit of coinOther) */
+  amountOther: BigIntStr;
+
+  /** Userop nonce, if this transfer occurred in a userop */
+  nonceMetadata?: Hex;
+
+  /** Memo, user-generated text for the transfer */
   memo?: string;
 }
 
@@ -168,10 +210,12 @@ export type DaimoAccountCall = {
 // the address of the claimer.
 // If the op claims a payment link, from = sender, to = claimer.
 // If the op is a swap, from = the pre-swap sender.
-export function getDisplayFromTo(op: DisplayOpEvent): [Address, Address] {
+export function getDisplayFromTo(op: TransferClog): [Address, Address] {
   if (op.type === "transfer") {
     if (op.preSwapTransfer) return [op.preSwapTransfer.from, op.to];
     else return [op.from, op.to];
+  } else if (op.type === "swap") {
+    return [op.from, op.to];
   } else {
     if (op.noteStatus.claimer?.addr === op.noteStatus.sender.addr) {
       // Self-transfer via payment link shows up as two payment link transfers
@@ -212,6 +256,52 @@ export function getSynthesizedMemo(
       return `${readableAmount} ${op.preSwapTransfer.coin.symbol} → ${coinName}`;
     } else {
       return `Accepted ${readableAmount} ${op.preSwapTransfer.coin.symbol} as ${coinName}`;
+    }
+  }
+}
+
+// TODO KAYLEE
+
+// Get memo text for an op
+// Either uses the memo field for standard transfers, e.g. "for ice cream"
+// Or generates a synthetic one for swaps, e.g. "5 USDT -> USDC" if short
+// or "Accepted 5 USDT as USDC" if long
+export function getSynthesizedMemo(
+  op: TransferClog,
+  daimoChain: DaimoChain,
+  short?: boolean
+) {
+  const chainConfig = env(daimoChain).chainConfig;
+  const coinName = chainConfig.tokenSymbol.toUpperCase();
+
+  if (op.memo) return op.memo;
+  if (op.type === "createLink" && op.noteStatus.memo) return op.noteStatus.memo;
+  if (op.type === "claimLink" && op.noteStatus.memo) return op.noteStatus.memo;
+
+  if (op.type !== "transfer" && op.type !== "swap") return null;
+  if (op.type === "transfer" && op.requestStatus) {
+    return op.requestStatus.memo;
+  } else if (
+    (op.type === "transfer" && op.preSwapTransfer) ||
+    op.type === "swap"
+  ) {
+    // TODO: do we need to explicitly handle preSwapTransfer && "transfer" for
+    // backwards compatibility?
+    const fromCoin =
+      op.type === "transfer" ? op.preSwapTransfer!.coin : op.coinOther;
+    const fromAmount =
+      op.type === "transfer" ? op.preSwapTransfer!.amount : op.amountOther;
+
+    if (isNativeETH(fromCoin.address, chainConfig)) {
+      return `ETH → ${coinName}`;
+    }
+
+    const readableAmount = getForeignCoinDisplayAmount(fromAmount, fromCoin);
+
+    if (short) {
+      return `${readableAmount} ${fromCoin.symbol} → ${coinName}`;
+    } else {
+      return `Accepted ${readableAmount} ${fromCoin.symbol} as ${coinName}`;
     }
   }
 }


### PR DESCRIPTION
Previously, we had `DisplayOpEvent`. 

This PR refactors naming from `DisplayOpEvent` to `TransferClog`. A `TransferClog` can be one of three things: 
- a `SimpleTransferClog` # alice to bob, same chain, same coin
- a `SimplePaymentLinkClog` # alice to payment link (and once bob claims, alice > payment link > bob), same chain, same coin
- a `SwapClog` # alice to bob, same chain, different coins (inbox, any-coin send)

This allows a transfer to accurately show the correct "from" and "to" endpoints in the case where a transaction occurs over the span of multiple transfer logs (e.g. needs to route over swap pools to get to end destination). 

**Before** (shows direct log transfer): 
<img width="200" alt="Screenshot 2024-06-25 at 2 10 24 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/aecc751a-eb97-4c1a-8afd-13a8911ec54c">

**After** (shows clog endpoints; pending and finalized):
<img width="200" alt="Screenshot 2024-06-25 at 2 10 20 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/eec439a8-dbc2-4842-861f-ca5006366df7">
<img width="200" alt="Screenshot 2024-06-25 at 3 00 55 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/c9f74124-1b19-493f-a64a-27ebaeee751f">

<img width="300" alt="Screenshot 2024-06-25 at 3 03 01 PM" src="https://github.com/daimo-eth/daimo/assets/62825936/da7a25ba-2e37-462e-98bc-23df1b253c35">
