### PR TITLE
Streamline latest block access & finalized block caching

### DIFF
--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -24,7 +24,6 @@ import { Address } from "viem";
 import { getExchangeRates } from "./getExchangeRates";
 import { getLinkStatus } from "./getLinkStatus";
 import { ProfileCache } from "./profile";
-import { ETHIndexer } from "../contract/ethIndexer";
 import { ForeignCoinIndexer } from "../contract/foreignCoinIndexer";
 import { HomeCoinIndexer } from "../contract/homeCoinIndexer";
 import { KeyRegistry } from "../contract/keyRegistry";
@@ -45,7 +44,6 @@ import { InviteCodeTracker } from "../offchain/inviteCodeTracker";
 import { InviteGraph } from "../offchain/inviteGraph";
 import { getAppVersionTracker } from "../server/appVersion";
 import { TrpcRequestContext } from "../server/trpc";
-import { Watcher } from "../shovel/watcher";
 
 export interface AccountHistoryResult {
   address: Address;

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -115,9 +115,7 @@ export async function getAccountHistory(
   console.log(log);
 
   // Get latest finalized block. Next account sync, fetch since this block.
-  const finBlock = await vc.publicClient.getBlock({
-    blockTag: "finalized",
-  });
+  const finBlock = await vc.getFinalizedBlock();
   if (finBlock.number == null) throw new Error("No finalized block");
   if (finBlock.number < sinceBlockNum) {
     console.log(`${log}: sinceBlockNum > finalized block ${finBlock.number}`);

--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -26,6 +26,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { IExternalApiCache } from "../db/externalApiCache";
 import { chainConfig, getEnvApi } from "../env";
 import { Telemetry } from "../server/telemetry";
+import { lazyCache } from "../utils/cache";
 import { memoize } from "../utils/func";
 
 function getTransportFromEnv() {
@@ -289,6 +290,14 @@ export class ViemClient {
     this.waitForReceipt(ret);
     return ret;
   }
+
+  getFinalizedBlock = lazyCache(
+    () => {
+      return this.publicClient.getBlock({ blockTag: "finalized" });
+    },
+    2_000,
+    1_000
+  );
 }
 
 export type ContractType<TAbi extends Abi> = GetContractReturnType<

--- a/packages/daimo-api/src/server/router.ts
+++ b/packages/daimo-api/src/server/router.ts
@@ -760,7 +760,7 @@ export function createRouter(
               blockNumber
             );
 
-            if (lastEmittedBlock > history.lastBlock) {
+            if (lastEmittedBlock >= history.lastBlock) {
               return;
             }
 

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -188,7 +188,7 @@ export class Watcher {
     this.isSlowIndexing = false;
   }
 
-  private async getShovelLatest(): Promise<number> {
+  async getShovelLatest(): Promise<number> {
     const result = await retryBackoff(`shovel-latest-query`, () =>
       this.pg.query(`select num from shovel.latest`)
     );

--- a/packages/daimo-api/src/utils/cache.ts
+++ b/packages/daimo-api/src/utils/cache.ts
@@ -1,0 +1,74 @@
+import { assert } from "@daimo/common";
+
+/**
+ * Lazily executes `fn` and caches the result ensuring only one execution at a time.
+ *
+ * `cacheTime` is duration in ms after cached value is considred expired,
+ * and must be refreshed before it can be returned.
+ *
+ * `staleTime` is an optional duration that refreshes
+ * the cache before it expires. Use it to avoid blocking after cache expires.
+ * Must be smaller than `cacheTime`.
+ *
+ */
+export function lazyCache<T>(
+  fn: () => Promise<T>,
+  cacheTime: number,
+  staleTime = cacheTime
+) {
+  const undefinedCachedValue = Symbol();
+  let currentPromise: Promise<T> | null = null;
+  let cachedValue: typeof undefinedCachedValue | T = undefinedCachedValue;
+  let cachedAt = -1;
+
+  assert(cacheTime >= staleTime);
+
+  return () => {
+    const now = performance.now();
+
+    // cache for the first time or when value becomes stale
+    if (!currentPromise && now > cachedAt + staleTime) {
+      currentPromise = fn();
+      currentPromise
+        .then((value) => {
+          cachedValue = value;
+          cachedAt = performance.now();
+          currentPromise = null;
+
+          console.log(`\t${new Date().toISOString()}\tdebug\tpromise set`);
+        })
+        .catch((e) => {
+          console.error(`[VIEM] pollFinalizedBlock error: ${e}`);
+
+          console.log(`\t${new Date().toISOString()}\tdebug\terror: ${e}`);
+
+          cachedValue = undefinedCachedValue;
+          cachedAt = -1;
+          currentPromise = null;
+        });
+    }
+
+    // fn is executing
+    if (currentPromise) {
+      // cache expired, waiting for current result
+      if (currentPromise && now > cachedAt + cacheTime) {
+        console.log(
+          `\t${new Date().toISOString()}\tdebug\tawaiting. cache expired`
+        );
+        return currentPromise as Promise<T>;
+      }
+
+      // no cached value yet, wait fn to finish
+      if (cachedValue === undefinedCachedValue) {
+        console.log(`\t${new Date().toISOString()}\tdebug\tawaiting. no cache`);
+
+        return currentPromise as Promise<T>;
+      }
+    }
+
+    console.log(`\t${new Date().toISOString()}\tdebug\treturning value`);
+
+    // we have a cached value, return it
+    return Promise.resolve(cachedValue as T);
+  };
+}

--- a/packages/daimo-api/src/utils/cache.ts
+++ b/packages/daimo-api/src/utils/cache.ts
@@ -34,13 +34,9 @@ export function lazyCache<T>(
           cachedValue = value;
           cachedAt = performance.now();
           currentPromise = null;
-
-          console.log(`\t${new Date().toISOString()}\tdebug\tpromise set`);
         })
         .catch((e) => {
-          console.error(`[VIEM] pollFinalizedBlock error: ${e}`);
-
-          console.log(`\t${new Date().toISOString()}\tdebug\terror: ${e}`);
+          console.error("lazyCache error", e);
 
           cachedValue = undefinedCachedValue;
           cachedAt = -1;
@@ -52,21 +48,14 @@ export function lazyCache<T>(
     if (currentPromise) {
       // cache expired, waiting for current result
       if (currentPromise && now > cachedAt + cacheTime) {
-        console.log(
-          `\t${new Date().toISOString()}\tdebug\tawaiting. cache expired`
-        );
         return currentPromise as Promise<T>;
       }
 
       // no cached value yet, wait fn to finish
       if (cachedValue === undefinedCachedValue) {
-        console.log(`\t${new Date().toISOString()}\tdebug\tawaiting. no cache`);
-
         return currentPromise as Promise<T>;
       }
     }
-
-    console.log(`\t${new Date().toISOString()}\tdebug\treturning value`);
 
     // we have a cached value, return it
     return Promise.resolve(cachedValue as T);


### PR DESCRIPTION
- Cache finalized block fetching globally. Before `getBlock` RPC call was made for every `getAccountHistory` request. Now the value is refreshed at most once every 1s. More: #1180
- Fix a bug where `AccountHistoryResult` could be one block behind. Now we get latest indexed block from Shovel database instead from internal `Watcher` indexer in `getAccountHistory`. This bug occurred when event loop called a new block notification callback in `Watcher.watch` before one in `onAccountUpdate` TRPC subscription.