### PR TITLE
api: resolve pending swaps for old ETH inbounds

### DIFF
--- a/packages/daimo-api/src/api/getSwapRoute.ts
+++ b/packages/daimo-api/src/api/getSwapRoute.ts
@@ -70,7 +70,8 @@ export async function getSwapQuote({
   const cacheUntil = t + 5 * 60; // 5 minutes
   const execDeadline = t + 10 * 60; // 10 minutes
 
-  const amountOutMinimum = amountOut - amountOut / 100n; // max slippage: 1%
+  const maxSlippagePercent = 5n;
+  const amountOutMinimum = amountOut - (maxSlippagePercent * amountOut) / 100n;
 
   // Special handling for fromCoin = native ETH
   const fromCoin = tokenReg.getToken(tokenIn);

--- a/packages/daimo-api/src/contract/foreignCoinIndexer.ts
+++ b/packages/daimo-api/src/contract/foreignCoinIndexer.ts
@@ -117,7 +117,8 @@ export class ForeignCoinIndexer extends Indexer {
           value: BigInt(row.v),
         };
       })
-      .filter((t) => this.tokenReg.hasToken(t.address))
+      .filter((t) => t.address !== chainConfig.tokenAddress) // not home coin
+      .filter((t) => this.tokenReg.hasToken(t.address)) // no spam tokens
       .map((t) => ({
         ...t,
         foreignToken: this.tokenReg.getToken(t.address)!,


### PR DESCRIPTION
* resolve pending swaps for old ETH inbounds
* remove excessive coupling in `foreignCoinIndexer` between CoinGecko responses & our own ForeignToken type. the former has `address: "0x..."`, the latter needs to have `token: "0x..."` & is used in Daimo API.

Both eth and erc20 receive should work now.