### PR TITLE
web: fix pfp ratio on invite page

### DIFF
--- a/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/l/[[...slug]]/page.tsx
@@ -79,6 +79,8 @@ async function LinkPageInner(props: LinkProps) {
                   style={{
                     objectFit: "cover",
                     borderRadius: "100px",
+                    width: "32px",
+                    height: "32px",
                   }}
                 />
               </div>


### PR DESCRIPTION
**Before**
<img width="500" alt="Screenshot 2024-07-17 at 1 26 21 PM" src="https://github.com/user-attachments/assets/f27ac7c6-2ec9-47da-9ea9-939eb06496c2">

**After**
<img width="500" alt="Screenshot 2024-07-17 at 1 26 15 PM" src="https://github.com/user-attachments/assets/81f5c77a-7188-443f-9e5b-b5824cbd95da">
