### PR TITLE
mobile: revert to normal polling, fix foreignCoinIndexer

### DIFF
--- a/apps/daimo-mobile/src/logic/notify.ts
+++ b/apps/daimo-mobile/src/logic/notify.ts
@@ -7,6 +7,7 @@ import { getAccountManager, useAccount } from "./accountManager";
 import { Log } from "./log";
 import { askOpenSettings } from "./settings";
 import { getRpcFunc } from "./trpc";
+import { syncAfterPushNotification } from "../sync/sync";
 
 /** Registers push notifications, if we have permission & haven't already. */
 export function useInitNotifications() {
@@ -24,7 +25,7 @@ export function useInitNotifications() {
       handleNotification: async (n: Notifications.Notification) => {
         const { title, body } = n.request.content;
         console.log(`[NOTIFY] handling push ${title} - ${body}`);
-
+        syncAfterPushNotification();
         return {
           shouldShowAlert: true,
           shouldPlaySound: true,
@@ -38,7 +39,11 @@ export function useInitNotifications() {
     const sub = AppState.addEventListener("change", async (state) => {
       if (state !== "active") return;
       console.log("[NOTIFY] app in foreground, clearing badge");
-
+      const count = await Notifications.getBadgeCountAsync();
+      if (count > 0) {
+        console.log("[NOTIFY] app opened with badge, syncing");
+        syncAfterPushNotification();
+      }
       await Notifications.setBadgeCountAsync(0);
     });
     return () => sub.remove();

--- a/apps/daimo-mobile/src/logic/trpc.tsx
+++ b/apps/daimo-mobile/src/logic/trpc.tsx
@@ -2,24 +2,14 @@ import type { AppRouter } from "@daimo/api";
 import { assert } from "@daimo/common";
 import { DaimoChain } from "@daimo/contract";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  CreateTRPCClientOptions,
-  createTRPCClient,
-  createWSClient,
-  httpBatchLink,
-  splitLink,
-  wsLink,
-} from "@trpc/client";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { nativeApplicationVersion, nativeBuildVersion } from "expo-application";
 import { ReactNode, createContext } from "react";
 import { Platform } from "react-native";
 
 import { getEnvMobile } from "../env";
-import {
-  updateNetworkState,
-  updateNetworkStateOnline,
-} from "../sync/networkState";
+import { updateNetworkStateOnline } from "../sync/networkState";
 
 const apiUrlT =
   getEnvMobile().DAIMO_APP_API_URL_TESTNET || getEnvMobile().DAIMO_APP_API_URL;
@@ -66,106 +56,73 @@ function chooseChain<T>({
   else return testnet;
 }
 
-const customTRPCfetch = async (
-  input: RequestInfo | URL,
-  init?: RequestInit
-) => {
-  const url = (() => {
-    if (input instanceof URL) return input;
-    else if (input instanceof Request) return new URL(input.url);
-    else return new URL(input);
-  })();
+function getOpts(daimoChain: DaimoChain) {
+  return {
+    links: [
+      httpBatchLink({
+        url: chooseChain({
+          daimoChain,
+          mainnet: apiUrlMainnetWithChain,
+          testnet: apiUrlTestnetWithChain,
+        }),
+        fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = (() => {
+            if (input instanceof URL) return input;
+            else if (input instanceof Request) return new URL(input.url);
+            else return new URL(input);
+          })();
 
-  init = init ?? {};
-  init.headers = (init.headers ?? {}) as Record<string, string>;
+          init = init ?? {};
+          init.headers = (init.headers ?? {}) as Record<string, string>;
 
-  const platform = `${Platform.OS} ${Platform.Version}`;
-  const version = `${nativeApplicationVersion} #${nativeBuildVersion}`;
-  init.headers["x-daimo-platform"] = platform;
-  init.headers["x-daimo-version"] = version;
+          const platform = `${Platform.OS} ${Platform.Version}`;
+          const version = `${nativeApplicationVersion} #${nativeBuildVersion}`;
+          init.headers["x-daimo-platform"] = platform;
+          init.headers["x-daimo-version"] = version;
 
-  // Fetch timeout
-  const { pathname } = url;
-  const func = pathname.split("/").slice(-1)[0] as keyof AppRouter;
-  const timeout = (() => {
-    if (func === "deployWallet") return 60_000; // 1 minute
-    else return 10_000; // default: 10 seconds
-  })();
-  console.log(`[TRPC] fetching ${url}, timeout ${timeout}ms`, init);
-  let promise: Promise<Response> | undefined;
-  const controller = new AbortController();
-  const timeoutID = setTimeout(() => {
-    if (promise == null) return; // Completed
-    console.log(`[TRPC] timed out after ${timeout}ms: ${input}`);
-    controller.abort();
-  }, timeout);
-  init.signal = controller.signal;
+          // Fetch timeout
+          const { pathname } = url;
+          const func = pathname.split("/").slice(-1)[0] as keyof AppRouter;
+          const timeout = (() => {
+            if (func === "deployWallet") return 60_000; // 1 minute
+            else return 10_000; // default: 10 seconds
+          })();
+          console.log(`[TRPC] fetching ${url}, timeout ${timeout}ms`, init);
+          let promise: Promise<Response> | undefined;
+          const controller = new AbortController();
+          const timeoutID = setTimeout(() => {
+            if (promise == null) return; // Completed
+            console.log(`[TRPC] timeout after ${timeout}ms: ${input}`);
+            controller.abort();
+          }, timeout);
+          init.signal = controller.signal;
 
-  // Fetch
-  const startMs = performance.now();
-  promise = fetch(input, init).then((res) => {
-    // When a request succeeds, mark us online immediately.
-    if (res.ok) updateNetworkStateOnline();
-    return res;
-  });
-  const ret = await promise;
-  promise = undefined;
-  clearTimeout(timeoutID);
-
-  // Log
-  const ms = (performance.now() - startMs) | 0;
-  const method = init.method || "GET";
-  console.log(`[TRPC] ${method} ${func} ${ret.status} in ${ms}ms`);
-
-  return ret;
-};
-
-function getTRPCOpts(
-  daimoChain: DaimoChain
-): CreateTRPCClientOptions<AppRouter> {
-  const url = chooseChain({
-    daimoChain,
-    mainnet: apiUrlMainnetWithChain,
-    testnet: apiUrlTestnetWithChain,
-  });
-
-  const daimoHttpLink = httpBatchLink({ url, fetch: customTRPCfetch });
-  let daimoLink = daimoHttpLink;
-
-  // TRPC client tries to connect to WebSocket on creation which breaks
-  // test environment that expects any resources to be defined explicitly in unit body
-  // or mocked altogether.
-  // Since TRPC client is currently tangled together with top-level code,
-  // we avoid using WebSocket link when running in no-browser environment (like tests.)
-  if (typeof WebSocket !== "undefined") {
-    console.log("[TRPC] WebSocket available, using ws for subscriptions");
-    const daimoWebsocketLink = wsLink({
-      client: createWSClient({
-        url,
-        retryDelayMs: () => 1_000,
-        onClose: () => {
-          console.warn("[TRPC] WebSocket closed");
-          updateNetworkState(() => {
-            return { status: "offline", syncAttemptsFailed: 0 };
+          // Fetch
+          const startMs = performance.now();
+          promise = fetch(input, init).then((res) => {
+            // When a request succeeds, mark us online immediately.
+            if (res.ok) updateNetworkStateOnline();
+            return res;
           });
+          const ret = await promise;
+          promise = undefined;
+          clearTimeout(timeoutID);
+
+          // Log
+          const ms = (performance.now() - startMs) | 0;
+          const method = init.method || "GET";
+          console.log(`[TRPC] ${method} ${func} ${ret.status} in ${ms}ms`);
+
+          return ret;
         },
       }),
-    });
-
-    daimoLink = splitLink({
-      condition: (op) => op.type === "subscription",
-      true: daimoWebsocketLink,
-      false: daimoHttpLink,
-    });
-  } else {
-    console.log("[TRPC] WebSocket not available, using http for subscriptions");
-  }
-
-  return { links: [daimoLink] };
+    ],
+    transformer: undefined,
+  };
 }
 
-const optsMainnet = getTRPCOpts("base");
-const optsTestnet = getTRPCOpts("baseSepolia");
+const optsMainnet = getOpts("base");
+const optsTestnet = getOpts("baseSepolia");
 const rpcHookMainnetClient = rpcHookMainnet.trpc.createClient(optsMainnet);
 const rpcHookTestnetClient = rpcHookTestnet.trpc.createClient(optsTestnet);
 

--- a/apps/daimo-mobile/src/sync/networkState.ts
+++ b/apps/daimo-mobile/src/sync/networkState.ts
@@ -21,6 +21,10 @@ export function useNetworkState() {
   return state;
 }
 
+export function getNetworkState() {
+  return currentState;
+}
+
 // Marks us as being back online
 export function updateNetworkStateOnline() {
   updateNetworkState((state) => ({ status: "online", syncAttemptsFailed: 0 }));

--- a/apps/daimo-mobile/src/sync/sync.ts
+++ b/apps/daimo-mobile/src/sync/sync.ts
@@ -1,119 +1,127 @@
 import { AccountHistoryResult } from "@daimo/api";
 import {
-  TransferClog,
   EAccount,
   OpStatus,
   PendingOpEvent,
+  TransferClog,
   amountToDollars,
   assert,
   assertNotNull,
+  now,
 } from "@daimo/common";
 import { daimoChainFromId } from "@daimo/contract";
+import * as SplashScreen from "expo-splash-screen";
 
-import { updateNetworkState, updateNetworkStateOnline } from "./networkState";
+import { getNetworkState, updateNetworkState } from "./networkState";
 import { getAccountManager } from "../logic/accountManager";
 import { SEND_DEADLINE_SECS } from "../logic/opSender";
 import { getRpcFunc } from "../logic/trpc";
 import { Account } from "../storage/account";
 
-class SyncManager {
-  manager = getAccountManager();
-  currentAccount: Account | null = null;
-
-  private _trpcUnsubscribe: (() => void) | null = null;
-
-  start() {
-    this.manager.addListener(this._onAccountChange);
-  }
-
-  stop() {
-    this.manager.removeListener(this._onAccountChange);
-
-    this.unsubscribe();
-  }
-
-  subscribe(account: Account) {
-    const daimoChain = daimoChainFromId(account.homeChainId);
-    const rpcFunc = getRpcFunc(daimoChain);
-
-    this.currentAccount = account;
-
-    const sub = rpcFunc.onAccountUpdate.subscribe(
-      {
-        address: account.address,
-        sinceBlockNum: 0,
-      },
-      {
-        onStarted: () => {
-          updateNetworkStateOnline();
-        },
-
-        onData: (data) => {
-          this.manager.transform((a) => applySync(a, data, false));
-        },
-      }
-    );
-
-    this._trpcUnsubscribe = sub.unsubscribe;
-  }
-
-  unsubscribe() {
-    this._trpcUnsubscribe?.();
-
-    this.currentAccount = null;
-
-    updateNetworkState(() => {
-      return {
-        status: "offline",
-        syncAttemptsFailed: 0,
-      };
-    });
-  }
-
-  _onAccountChange = (newAccount: Account | null) => {
-    if (!newAccount) {
-      this.unsubscribe();
-
-      return;
-    }
-
-    // do nothing if we still use the same wallet
-    if (this.currentAccount?.address === newAccount.address) {
-      return;
-    }
-
-    this.unsubscribe();
-
-    this.subscribe(newAccount);
-  };
-}
-
+/**
+ * Sync strategy:
+ * - On app load, load account from storage
+ * - Then, sync from API
+ * - After, sync from API:
+ * - ...immediately on push notification
+ * - ...frequently while there's a pending transaction
+ * - ...occasionally otherwise
+ */
 export function startSync() {
   console.log("[SYNC] APP LOAD, starting sync");
+  maybeSync(true)
+    .then((status) => {
+      if (status !== "failed") return;
+      updateNetworkState(() => ({ status: "offline", syncAttemptsFailed: 1 }));
+    })
+    .finally(() => SplashScreen.hideAsync());
+  setInterval(maybeSync, 1_000);
+}
 
-  const manager = new SyncManager();
+let lastSyncS = 0;
+let lastPushNotificationS = 0;
 
-  manager.start();
+/** Sync more frequently for a few seconds after each push notification. */
+export function syncAfterPushNotification() {
+  lastPushNotificationS = now();
+}
 
-  return manager;
+type SyncStatus = "success" | "failed" | "skipped" | "skipped";
+
+async function maybeSync(fromScratch?: boolean): Promise<SyncStatus> {
+  const manager = getAccountManager();
+  const account = manager.getAccount();
+  if (account == null) return "skipped";
+
+  // Synced recently? Wait first.
+  const nowS = now();
+  let intervalS = 10;
+
+  // Sync faster for 1. pending ops or expired swaps, and 2. recently-failed sync
+  if (hasPendingOps(account) || hasCacheExpiredSwaps(account)) {
+    intervalS = 1;
+  }
+
+  const netState = getNetworkState();
+  if (netState.status === "online" && netState.syncAttemptsFailed > 0) {
+    intervalS = 1;
+  }
+
+  if (fromScratch) {
+    return await resync(`initial sync from scratch`, true);
+  } else if (lastPushNotificationS + 10 > nowS) {
+    return await resync(
+      `push notification ${nowS - lastPushNotificationS}s ago`
+    );
+  } else if (lastSyncS + intervalS > nowS) {
+    console.log(`[SYNC] skipping sync, attempted sync recently`);
+    return "skipped";
+  } else {
+    return await resync(`interval ${intervalS}s`);
+  }
+}
+
+function hasPendingOps(account: Account) {
+  return (
+    account.recentTransfers.find((t) => t.status === "pending") != null ||
+    account.pendingKeyRotation.length > 0
+  );
+}
+
+function hasCacheExpiredSwaps(account: Account) {
+  return account.proposedSwaps.some((s) => s.cacheUntil < now());
 }
 
 /** Gets latest balance & history for this account, in the background. */
-export async function resync(reason: string, fromScratch?: boolean) {
+export async function resync(
+  reason: string,
+  fromScratch?: boolean
+): Promise<SyncStatus> {
   const manager = getAccountManager();
   const accOld = manager.getAccount();
   assert(!!accOld, `no account, skipping sync: ${reason}`);
 
-  console.log(`[RESYNC] New ${accOld.name}, ${reason}`);
+  console.log(`[SYNC] RESYNC ${accOld.name}, ${reason}`);
+  lastSyncS = now();
 
   try {
     const res = await fetchSync(accOld, fromScratch);
     assertNotNull(manager.getAccount(), "deleted during sync");
-
     manager.transform((a) => applySync(a, res, !!fromScratch));
-    console.log(`[RESYNC] SUCCEEDED ${accOld.name}`);
+    console.log(`[SYNC] SUCCEEDED ${accOld.name}`);
+    // We are automatically marked online when any RPC req succeeds
+    return "success";
   } catch (e) {
-    console.error(`[RESYNC] FAILED ${accOld.name}`, e);
+    console.error(`[SYNC] FAILED ${accOld.name}`, e);
+    // Mark offline
+    updateNetworkState((state) => {
+      const syncAttemptsFailed = state.syncAttemptsFailed + 1;
+      return {
+        syncAttemptsFailed,
+        status: syncAttemptsFailed > 3 ? "offline" : "online",
+      };
+    });
+    return "failed";
   }
 }
 

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -133,7 +133,7 @@ export async function getAccountHistory(
     addr: address,
     sinceBlockNum: BigInt(sinceBlockNum),
   });
-  let elapsedMs = performance.now() - startMs;
+  let elapsedMs = (performance.now() - startMs) | 0;
   console.log(`${log}: ${elapsedMs}ms ${transferClogs.length} logs`);
 
   // Get named accounts
@@ -166,7 +166,7 @@ export async function getAccountHistory(
   const invitees = inviteeAddrs
     .map((addr) => nameReg.getDaimoAccount(addr))
     .filter((acc) => acc != null) as EAccount[];
-  elapsedMs = performance.now() - startMs;
+  elapsedMs = (performance.now() - startMs) | 0;
   console.log(`${log}: ${elapsedMs}ms: ${invitees.length} invitees`);
 
   // Get pfps from linked accounts
@@ -177,7 +177,7 @@ export async function getAccountHistory(
 
   // Get proposed swaps of non-home coin tokens for address
   const swaps = await foreignCoinIndexer.getProposedSwapsForAddr(address);
-  elapsedMs = performance.now() - startMs;
+  elapsedMs = (performance.now() - startMs) | 0;
   console.log(`${log}: ${elapsedMs}: ${swaps.length} swaps`);
 
   // Get exchange rates
@@ -226,8 +226,8 @@ export async function getAccountHistory(
   // Suggest an action to the user, like backing up their account
   const suggestedActions = getSuggestedActions(eAcc, ret, ctx);
 
-  elapsedMs = Date.now() - startMs;
-  console.log(`${log}: ${elapsedMs}: done, returning`);
+  elapsedMs = (performance.now() - startMs) | 0;
+  console.log(`${log}: ${elapsedMs}ms: done, returning`);
   return { ...ret, suggestedActions };
 }
 


### PR DESCRIPTION
### Mobile > API polling

websocket implementation was unreliable. fixes spurious offline indicator.

we are still using websockets to talk to ethererum RPC (both API & shovel), & postgres NOTIFY for api to get rapid updates from shovel.

### foreignCoinIndexer

This PR deletes the materialized views that were causing us grief. As a stopgap till a more permanent indexer fix, this should restore inbox functionality, including receiving ETH.