### PR TITLE
Add padding to bottom of search results

### DIFF
--- a/apps/daimo-mobile/src/view/shared/SearchResults.tsx
+++ b/apps/daimo-mobile/src/view/shared/SearchResults.tsx
@@ -96,7 +96,7 @@ function SearchResultsScroll({
       {res.status === "success" &&
         res.recipients.length === 0 &&
         prefix !== "" && <NoSearchResults />}
-      <Spacer h={32} />
+      <Spacer h={64} />
       {Platform.OS === "ios" && <Spacer h={kbH} />}
     </ScrollView>
   );


### PR DESCRIPTION
Fixes https://github.com/daimo-eth/daimo/issues/1070

Bottom recent recipient doesn't get cut off anymore
<img width="309" alt="Screenshot 2024-07-22 at 3 36 03 PM" src="https://github.com/user-attachments/assets/775d6d9c-8eb8-4d53-8b2a-5e1d3bf30631">
