### PR TITLE
web: I18N

### DIFF
--- a/apps/daimo-web/src/app/HomePage.tsx
+++ b/apps/daimo-web/src/app/HomePage.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { SectionFAQ } from "./SectionFAQ";
+import { SectionHero } from "./SectionHero";
+import { SectionTestimonial } from "./SectionTestimonial";
+import { SectionWhyDaimo } from "./SectionWhyDaimo";
+import { Footer } from "../components/Footer";
+import { Header } from "../components/Header";
+import { HeroBackground } from "../components/HeroBackground";
+import { I18NProvider } from "../i18n/context";
+
+export function HomePage({ lang }: { lang: string | null }) {
+  return (
+    <I18NProvider lang={lang}>
+      <HeroBackground>
+        <Header />
+        <SectionHero />
+      </HeroBackground>
+      <SectionWhyDaimo />
+      <SectionTestimonial />
+      <SectionFAQ />
+      <Footer />
+    </I18NProvider>
+  );
+}

--- a/apps/daimo-web/src/app/SectionHero.tsx
+++ b/apps/daimo-web/src/app/SectionHero.tsx
@@ -7,8 +7,11 @@ import {
   DownloadLinkButton,
   DownloadLinkButtonMobileNav,
 } from "../components/DownloadLink";
+import { useI18N } from "../i18n/context";
 
 export function SectionHero() {
+  const i18n = useI18N();
+
   return (
     <section className="overflow-hidden md:pb-28 px-8 m-auto max-w-screen-xl bg-[#000000]/20 lg:bg-[#000]/0">
       <motion.div
@@ -23,11 +26,8 @@ export function SectionHero() {
           transition={{ duration: 0.5, delay: 0.3, ease: "easeInOut" }}
           className="flex-1 flex flex-col justify-center space-y-8 md:space-y-12"
         >
-          <HeroH1>Your own bank, on Ethereum.</HeroH1>
-          <HeroH2>
-            Store money using secure hardware on your phone. Yours alone, like
-            cash.
-          </HeroH2>
+          <HeroH1>{i18n.home.heroH1()}</HeroH1>
+          <HeroH2>{i18n.home.heroH2()}</HeroH2>
           <div className="hidden md:flex md:flex-row md:items-center md:space-x-[20px] lg:space-x-[36px] md:pt-8">
             <DownloadLinkButton />
             <Link

--- a/apps/daimo-web/src/app/l/[[...slug]]/LinkPage.tsx
+++ b/apps/daimo-web/src/app/l/[[...slug]]/LinkPage.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Image from "next/image";
+
+import { CallToAction } from "../../../components/CallToAction";
+import { chainsDaimoL2, Providers } from "../../../components/Providers";
+import { I18NProvider } from "../../../i18n/context";
+import { LinkStatusDesc } from "../../../utils/linkStatus";
+
+export default function LinkPage({
+  lang,
+  statusDesc,
+  pfp,
+}: {
+  lang: string | null;
+  statusDesc: LinkStatusDesc | null;
+  pfp: string | undefined;
+}) {
+  return (
+    <Providers chains={chainsDaimoL2}>
+      <I18NProvider lang={lang}>
+        <LinkPageInner {...{ statusDesc, pfp }} />
+      </I18NProvider>
+    </Providers>
+  );
+}
+
+function LinkPageInner({
+  statusDesc,
+  pfp,
+}: {
+  statusDesc: LinkStatusDesc | null;
+  pfp: string | undefined;
+}) {
+  const { name, action, dollars, description, linkStatus, memo } =
+    statusDesc || {
+      title: "Daimo",
+      description: "Payments on Ethereum",
+    };
+
+  return (
+    <main className="max-w-md mx-auto px-4">
+      <center>
+        <div className="h-16" />
+        <Image src="/logo-web.png" alt="Daimo" width="96" height="96" />
+
+        <div className="h-12" />
+
+        <div className="flex text-xl font-semibold justify-center items-center">
+          <div className="flex flex-row gap-x-2">
+            {pfp && (
+              <div
+                className="flex h-[32px] w-[32px]"
+                style={{ position: "relative" }}
+              >
+                <Image
+                  src={pfp}
+                  alt={"Profile"}
+                  width={32}
+                  height={32}
+                  style={{
+                    objectFit: "cover",
+                    borderRadius: "100px",
+                    width: "32px",
+                    height: "32px",
+                  }}
+                />
+              </div>
+            )}
+
+            <div className="flex items-center gap-x-1">
+              {name && <span>{name}</span>}
+              {action && <span className="text-grayMid">{" " + action}</span>}
+            </div>
+          </div>
+        </div>
+        {dollars && (
+          <>
+            <div className="h-4" />
+            <div className="text-6xl font-semibold">${dollars}</div>
+          </>
+        )}
+        {memo && (
+          <>
+            <div className="h-4" />
+            <p className="text-xl italic font-semibold text-grayMid">{memo}</p>
+          </>
+        )}
+        <div className="h-9" />
+        <CallToAction {...{ description, linkStatus }} />
+      </center>
+    </main>
+  );
+}

--- a/apps/daimo-web/src/app/l/[[...slug]]/LinkPageProps.ts
+++ b/apps/daimo-web/src/app/l/[[...slug]]/LinkPageProps.ts
@@ -1,0 +1,15 @@
+import { daimoLinkBaseV2 } from "@daimo/common";
+
+export type LinkPageProps = {
+  params: { slug?: string[] };
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+/// Reconstructs deeplink absolute URL from route params
+export function getUrl(props: LinkPageProps): string {
+  const path = (props.params.slug || []).join("/");
+  const queryString = new URLSearchParams(
+    props.searchParams as Record<string, string>
+  ).toString();
+  return `${daimoLinkBaseV2}/${path}?${queryString}`;
+}

--- a/apps/daimo-web/src/app/layout.tsx
+++ b/apps/daimo-web/src/app/layout.tsx
@@ -1,36 +1,44 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 
 import "@rainbow-me/rainbowkit/styles.css";
 import { neueMontreal } from "../fonts/font";
-import "./globals.css";
+import { getI18N } from "../i18n";
 import { getAbsoluteUrl } from "../utils/getAbsoluteUrl";
+import "./globals.css";
 
-export const metadata: Metadata = {
-  metadataBase: new URL(getAbsoluteUrl("/")),
-  title: "Daimo",
-  description: "Stablecoin payments app",
-  icons: {
-    icon: "/logo-web-favicon.png",
-  },
-  openGraph: {
-    images: [
-      {
-        url: "/logo-link-preview.png",
-        alt: "Daimo",
-        width: 128,
-        height: 105,
-      },
-    ],
-  },
-  viewport: "width=device-width, initial-scale=1, minimum-scale=0.4",
-};
+export function generateMetadata(): Metadata {
+  const i18n = getI18N(headers().get("accept-language"));
+  return {
+    metadataBase: new URL(getAbsoluteUrl("/")),
+    title: i18n.meta.title(),
+    description: i18n.meta.description(),
+    icons: {
+      icon: "/logo-web-favicon.png",
+    },
+    openGraph: {
+      images: [
+        {
+          url: "/logo-link-preview.png",
+          alt: "Daimo",
+          width: 128,
+          height: 105,
+        },
+      ],
+    },
+    viewport: "width=device-width, initial-scale=1, minimum-scale=0.4",
+  };
+}
 
-function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const i18n = getI18N(headers().get("accept-language"));
   return (
-    <html lang="en" className={`${neueMontreal.variable} font-sans`}>
+    <html lang={i18n.lang} className={`${neueMontreal.variable} font-sans`}>
       <body>{children}</body>
     </html>
   );
 }
-
-export default RootLayout;

--- a/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
+++ b/apps/daimo-web/src/app/link/[[...slug]]/page.tsx
@@ -20,6 +20,12 @@ import { Providers, chainsDaimoL2 } from "../../../components/Providers";
 import { getAbsoluteUrl } from "../../../utils/getAbsoluteUrl";
 import { rpc } from "../../../utils/rpc";
 
+//
+// DEPRECATED
+// This page exists solely for backcompat for old /link/ deeplinks.
+// No need to translate to other languages.
+//
+
 // Opt out of caching for all data requests in the route segment
 export const dynamic = "force-dynamic";
 

--- a/apps/daimo-web/src/app/page.tsx
+++ b/apps/daimo-web/src/app/page.tsx
@@ -1,22 +1,6 @@
-import { SectionFAQ } from "./SectionFAQ";
-import { SectionHero } from "./SectionHero";
-import { SectionTestimonial } from "./SectionTestimonial";
-import { SectionWhyDaimo } from "./SectionWhyDaimo";
-import { Footer } from "../components/Footer";
-import { Header } from "../components/Header";
-import { HeroBackground } from "../components/HeroBackground";
+import { HomePage } from "./HomePage";
+import { getReqLang } from "../i18n/server";
 
-export default function HomePage() {
-  return (
-    <>
-      <HeroBackground>
-        <Header />
-        <SectionHero />
-      </HeroBackground>
-      <SectionWhyDaimo />
-      <SectionTestimonial />
-      <SectionFAQ />
-      <Footer />
-    </>
-  );
+export default function HomePageWrap() {
+  return <HomePage lang={getReqLang()} />;
 }

--- a/apps/daimo-web/src/components/CallToAction.tsx
+++ b/apps/daimo-web/src/components/CallToAction.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 
 import { AppOrWalletCTA } from "./AppOrWalletCTA";
 import { PrimaryOpenInAppButton, SecondaryButton } from "./buttons";
+import { useI18N } from "../i18n/context";
 
 export function CallToAction({
   description,
@@ -18,6 +19,9 @@ export function CallToAction({
   description: string;
   linkStatus?: DaimoLinkStatus;
 }) {
+  const i18n = useI18N();
+  const i18 = i18n.callToAction;
+
   const [directDeepLink, setDirectDeepLink] = useState<string>("");
 
   const isInvite = !!linkStatus && getInviteStatus(linkStatus).isValid;
@@ -56,7 +60,7 @@ export function CallToAction({
               window.open(directDeepLink, "_blank");
             }}
           >
-            ALREADY HAVE IT? OPEN IN APP
+            {i18.openInApp()}
           </SecondaryButton>
         </>
       )}

--- a/apps/daimo-web/src/components/buttons.tsx
+++ b/apps/daimo-web/src/components/buttons.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { useI18N } from "../i18n/context";
 import { detectPlatform, downloadMetadata } from "../utils/platform";
 
 export function PrimaryOpenInAppButton({
@@ -11,6 +12,9 @@ export function PrimaryOpenInAppButton({
   inviteDeepLink?: string;
   disabled?: boolean;
 }) {
+  const i18n = useI18N();
+  const i18 = i18n.callToAction;
+
   const [justCopied, setJustCopied] = useState(false);
 
   const onClick = async () => {
@@ -35,8 +39,10 @@ export function PrimaryOpenInAppButton({
       buttonType={justCopied ? "success" : undefined}
     >
       {justCopied
-        ? "COPIED, REDIRECTING..."
-        : (inviteDeepLink ? "COPY INVITE & " : "") + "INSTALL DAIMO"}
+        ? i18.justCopiedLink()
+        : inviteDeepLink
+        ? i18.copyAndInstall()
+        : i18.install()}
     </PrimaryButton>
   );
 }

--- a/apps/daimo-web/src/i18n/context.tsx
+++ b/apps/daimo-web/src/i18n/context.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+import { getI18N } from ".";
+import { LangDef, en } from "./languages/en";
+
+const I18NContext = createContext<LangDef>(en);
+
+export function I18NProvider({
+  lang,
+  children,
+}: {
+  lang: string | null;
+  children: React.ReactNode;
+}) {
+  const i18n = getI18N(lang);
+  return <I18NContext.Provider value={i18n}>{children}</I18NContext.Provider>;
+}
+
+export function useI18N(): LangDef {
+  return useContext(I18NContext);
+}

--- a/apps/daimo-web/src/i18n/index.ts
+++ b/apps/daimo-web/src/i18n/index.ts
@@ -1,0 +1,14 @@
+import { en, LangDef } from "./languages/en";
+import { es } from "./languages/es";
+
+export function getI18N(lang: string | null): LangDef {
+  const langCode = (lang || "en").slice(0, 2);
+
+  switch (langCode) {
+    case "es":
+      return es;
+    case "en":
+    default:
+      return en;
+  }
+}

--- a/apps/daimo-web/src/i18n/languages/en.ts
+++ b/apps/daimo-web/src/i18n/languages/en.ts
@@ -1,0 +1,21 @@
+// TODO: extract UI text into this file
+export const en = {
+  lang: "en",
+  meta: {
+    title: () => "Daimo",
+    description: () => "Stablecoin payments app",
+  },
+  home: {
+    heroH1: () => "Your own bank, on Ethereum.",
+    heroH2: () =>
+      "Store money using secure hardware on your phone. Yours alone, like cash.",
+  },
+  callToAction: {
+    justCopiedLink: () => "COPIED, REDIRECTING...",
+    copyAndInstall: () => "COPY INVITE & INSTALL DAIMO",
+    install: () => "INSTALL DAIMO",
+    openInApp: () => "ALREADY HAVE IT? OPEN IN APP",
+  },
+};
+
+export type LangDef = typeof en;

--- a/apps/daimo-web/src/i18n/languages/es.ts
+++ b/apps/daimo-web/src/i18n/languages/es.ts
@@ -1,0 +1,21 @@
+import { LangDef } from "./en";
+
+// TODO: translate
+export const es: LangDef = {
+  lang: "es",
+  meta: {
+    title: () => "Daimo",
+    description: () => "App de pagos stablecoin",
+  },
+  home: {
+    heroH1: () => "Tu propio banco, en Ethereum.",
+    heroH2: () =>
+      "Almacena dinero usando hardware seguro en tu teléfono. Tu propio, como efectivo.",
+  },
+  callToAction: {
+    justCopiedLink: () => "COPIADO, REDIRIGIENDO...",
+    copyAndInstall: () => "COPIAR INVITACIÓN E INSTALAR",
+    install: () => "INSTALAR DAIMO",
+    openInApp: () => "¿YA LO TIENES? ABRIR EN LA APP",
+  },
+};

--- a/apps/daimo-web/src/i18n/server.ts
+++ b/apps/daimo-web/src/i18n/server.ts
@@ -1,0 +1,5 @@
+import { headers } from "next/headers";
+
+export function getReqLang(): string | null {
+  return headers().get("accept-language");
+}


### PR DESCRIPTION
cc @Ethanol48 

I've implemented a minimalist I18N setup that matches the approach we took for `daimo-api`, `mobile`, and `common`.

- All `page.tsx` components will be Next server components. They can handle metadata, data fetching, and locale. See the two `page.tsx` modified in this PR for examples.
- All actual rendering can happen in client components split out from the parent page. See, for example, `LinkPage.tsx`. These take `lang` as a prop, and they use `I18NProvider` to provide language context for child components.
- Finally, the interface components use the `useI18N()` hook to get internationalization.

The legacy `/link/...` page doesn't need to be translated. I've marked it as deprecated.

Have a great weekend & let me know if you run into any issues 🫡