### PR TITLE
API: fix nonce issue

### DIFF
--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -190,30 +190,14 @@ export class ViemClient {
     );
   }
 
-  private async waitForReceipt(hash: Hex, maxWaitMs: number = 10_000) {
+  private async waitForReceipt(hash: Hex, timeoutMs: number = 10_000) {
     let receiptStatus = "";
 
     try {
-      const receiptPromise = this.publicClient.waitForTransactionReceipt({
+      const receipt = await this.publicClient.waitForTransactionReceipt({
         hash,
+        timeout: timeoutMs,
       });
-      const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(
-          () =>
-            reject(
-              new Error(
-                `Timed out after ${maxWaitMs}ms waiting for receipt ${hash}`
-              )
-            ),
-          maxWaitMs
-        )
-      );
-
-      // Wait at most maxWaitMs milliseconds for the receipt
-      const receipt = (await Promise.race([
-        receiptPromise,
-        timeoutPromise,
-      ])) as TransactionReceipt;
       console.log(`[VIEM] waitForReceipt ${hash}: ${JSON.stringify(receipt)}`);
 
       receiptStatus = receipt.status;
@@ -244,7 +228,7 @@ export class ViemClient {
   private async updateNonce() {
     const txCount = await this.publicClient.getTransactionCount({
       address: this.walletClient.account.address,
-      blockTag: "pending",
+      blockTag: "latest",
     });
     console.log(
       `[VIEM] nonce: got tx count ${txCount}, updating nonce ${this.nextNonce}`

--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -10,6 +10,7 @@ import {
   PublicClient,
   SendTransactionParameters,
   SendTransactionReturnType,
+  TransactionReceipt,
   Transport,
   WalletClient,
   WriteContractParameters,
@@ -120,6 +121,7 @@ export class ViemClient {
   // Lock to ensure sequential nonce for walletClient writes
   private lockNonce = new AwaitLock();
   private nextNonce = 0;
+  private pendingTxCount = 0;
   public account: Account;
 
   constructor(
@@ -188,18 +190,50 @@ export class ViemClient {
     );
   }
 
-  private async waitForReceipt(hash: Hex) {
+  private async waitForReceipt(hash: Hex, maxWaitMs: number = 10_000) {
+    let receiptStatus = "";
+
     try {
-      const receipt = await this.publicClient.waitForTransactionReceipt({
+      const receiptPromise = this.publicClient.waitForTransactionReceipt({
         hash,
       });
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Timed out after ${maxWaitMs}ms waiting for receipt ${hash}`
+              )
+            ),
+          maxWaitMs
+        )
+      );
+
+      // Wait at most maxWaitMs milliseconds for the receipt
+      const receipt = (await Promise.race([
+        receiptPromise,
+        timeoutPromise,
+      ])) as TransactionReceipt;
       console.log(`[VIEM] waitForReceipt ${hash}: ${JSON.stringify(receipt)}`);
-      if (receipt.status !== "success") {
+
+      receiptStatus = receipt.status;
+      if (receiptStatus !== "success") {
         this.onReceiptError(hash, JSON.stringify(receipt));
       }
     } catch (e) {
       console.error(`[VIEM] waitForReceipt ${hash} error: ${e}`);
       this.onReceiptError(hash, e);
+    } finally {
+      await this.lockNonce.acquireAsync();
+
+      if (receiptStatus === "success") {
+        this.nextNonce += 1;
+        this.pendingTxCount -= 1;
+      } else {
+        this.pendingTxCount -= 1;
+      }
+
+      this.lockNonce.release();
     }
   }
 
@@ -241,7 +275,9 @@ export class ViemClient {
         `[VIEM] tx ${localTxId} ${elapsedMs()}ms: got nonce ${this.nextNonce}`
       );
 
-      args.nonce = this.nextNonce; // Override nonce
+      // Override nonce with nonce estimate. Optimistically assumes that
+      // all pending transactions will succeed.
+      args.nonce = this.nextNonce + this.pendingTxCount;
       args.gas = 2_000_000n; // Saves estimateGas roundtrip
       args.chain = null; // Saves eth_chainId roundtrip, see https://github.com/wevm/viem/pull/474#discussion_r1190476819
 
@@ -249,8 +285,7 @@ export class ViemClient {
 
       console.log(`[VIEM] tx ${localTxId} ${elapsedMs()}ms: submitted: ${ret}`);
 
-      // Increment nonce for later
-      this.nextNonce += 1;
+      this.pendingTxCount += 1;
       return ret;
     } finally {
       this.lockNonce.release();

--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -10,7 +10,6 @@ import {
   PublicClient,
   SendTransactionParameters,
   SendTransactionReturnType,
-  TransactionReceipt,
   Transport,
   WalletClient,
   WriteContractParameters,


### PR DESCRIPTION
Fixes nonce issue in https://github.com/daimo-eth/daimo/issues/1246

## Example
5 transactions with nonces 1, 2, 3, 4, 5 get sent. Tx 1 gets rejected but tx 2-5 are queued by the sequencer.

Without the fix, the client would send new txs with nonces 6, 7, 8, ... These new txs will fail with a "receipt error" because a tx with nonce 1 hasn't been sent yet.

With the fix, the client will time out waiting for the receipts of txs 1-5, then it would send the next tx with nonce 1. Txs 2-5 will get processed. `updateNonce` will query the next nonce from the RPC and set the nonce of the next tx to 6.