### PR TITLE
release: 1.9.3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -20,11 +20,12 @@ just outright bugs.
 - [ ] Create payment link with memo. Ensure memo appears.
 - [ ] Cancel payment link.
 - [ ] Create request link with memo. Ensure the memo appears.
-- [ ] Add device + Use existing onboarding (test transactions work on both devices)
+- [ ] Add device + Use existing onboarding
 - [ ] Remove device
 - [ ] Open History
 - [ ] Account screen: Send Debug Log
 - [ ] Debug log looks clean
+- [ ] Send to USDC Sepolia
 
 ### Android
 
@@ -54,6 +55,8 @@ Smoke test, particularly for visual regressions:
 - [ ] Prod website deploys correctly
 - [ ] Logs clean
 - [ ] Sentry clean
+- [ ] Send to USDC Arbitrum
+- [ ] Receive Base ETH, test inbox claim
 
 ### Prod smoke test
 

--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from "@expo/config";
 
 const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
-const VERSION = "1.9.3";
+const VERSION = "1.9.4";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
**Any-chain send.**

## Release checklist

### API and webapp

- [x] Branch from `master`
- [x] Testnet API deployed correctly
- [x] Testnet webapp deployed correctly

### iOS

Watch all of the following interactions closely for jank and UX regressions, not
just outright bugs.

- [x] Install from private TestFlight
- [x] Create testnet account
- [x] Faucet + notification should appear automatically.
- [x] Send payment. **Duplicate rows, pending + confirmed**
- [x] Create payment link with memo. Ensure memo appears. **Duplicate rows, as above.**
- [x] Cancel payment link.
- [x] Create request link with memo. Ensure the memo appears.
- [x] Add device + Use existing onboarding
- [x] Remove device
- [x] Open History
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean
- [x] **Send to USDC Sepolia**

### Android

- [x] Install from Play Store closed track
- [x] Clear account (create one first, if necessary)
- [x] Create account
- [x] Faucet + notification should appear automatically
- [x] Send payment
- [x] Create & cancel payment link
- [x] Create & cancel request to another account, with memo
- [x] Account screen: Send Debug Log
- [x] Debug log looks clean

### macOS

Smoke test, particularly for visual regressions:

- [x] Install from Testflight
- [x] Send payment
- [x] Share invite link
- [x] Delete account and restore from passkey backup

### Push to prod

N/A, not updating prod API until later.

### Prod smoke test

- [x] Log back into prod account
- [x] Send a transfer
- [x] Notification appears on confirmation
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.
- [x] **Send to other chains.**

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
