### PR TITLE
api: fix tryInsertPushNotifications

### DIFF
--- a/packages/daimo-api/src/db/db.ts
+++ b/packages/daimo-api/src/db/db.ts
@@ -533,6 +533,7 @@ export class DB {
         push_key: push.key,
         push_json: JSON.stringify(push.expoPush),
       })
+      .onConflict((b) => b.doNothing())
       .executeTakeFirst();
     return Number(res.numInsertedOrUpdatedRows || 0);
   }


### PR DESCRIPTION
Fixes API error:
```
error: duplicate key value violates unique constraint "push_notification_address_push_key_key"
```
...`tryInsertPushNotifications` is meant to dedupe outbound push notifications > now does that correctly
