### PR TITLE
api: hotfix watcher, ShovelSquared

### DIFF
--- a/packages/daimo-api/src/api/healthCheck.ts
+++ b/packages/daimo-api/src/api/healthCheck.ts
@@ -43,7 +43,7 @@ async function healthCheckInner(
   let status = "healthy";
   if (indexer.lastGoodTickS < nowS - 10) {
     status = "watcher-not-ticking";
-  } else if (indexer.shovelLatest < indexer.rpcLatest - 5) {
+  } else if (indexer.indexLatest < indexer.rpcLatest - 5) {
     status = "watcher-behind-rpc";
   } else if (node.mem.heapMB / node.mem.maxMB > 0.8) {
     status = "node-mem-full";

--- a/packages/daimo-api/src/contract/indexer.ts
+++ b/packages/daimo-api/src/contract/indexer.ts
@@ -8,7 +8,7 @@ export abstract class Indexer {
   public readonly name: string;
   protected lastProcessedBlock = 0;
 
-  protected readonly shovelSource: { event: string; trace: string };
+  public readonly shovelSource: { event: string; trace: string };
 
   constructor(name: string) {
     console.log(`[INDEXER] ${name} constructed`);

--- a/packages/daimo-api/src/contract/nameRegistry.ts
+++ b/packages/daimo-api/src/contract/nameRegistry.ts
@@ -149,7 +149,6 @@ export class NameRegistry extends Indexer {
 
     // Ignore if already present
     if (this.accounts.find((a) => a.addr === reg.addr)) {
-      console.log(`[NAME-REG] skipping already-cached account ${reg.name}`);
       return;
     }
 

--- a/packages/daimo-common/src/currencies.ts
+++ b/packages/daimo-common/src/currencies.ts
@@ -17,10 +17,11 @@ export const currencyRateUSD: CurrencyExchangeRate = {
 const data: [string, string, string, number][] = [
   ["Euro", "€", "EUR", 2],
   ["Argentine Peso", "ARS", "ARS", 0],
+  ["Bolivian Boliviano", "$b", "BOB", 0],
+  ["Turkish Lira", "₺", "TRY", 0],
+  ["New Taiwan Dollar", "NT$", "TWD", 0],
   ["Ukrainian Hryvnia", "₴", "UAH", 0],
   ["Naira", "₦", "NGN", 0],
-  ["New Taiwan Dollar", "NT$", "TWD", 0],
-  ["Turkish Lira", "₺", "TRY", 0],
   ["Swiss Franc", "₣", "CHF", 2],
   ["Japanese Yen", "¥", "JPY", 0],
   ["Korean Won", "₩", "KRW", 0],
@@ -29,7 +30,6 @@ const data: [string, string, string, number][] = [
   ["Canadian Dollar", "C$", "CAD", 2],
   ["Australian Dollar", "A$", "AUD", 2],
   ["Singapore Dollar", "S$", "SGD", 2],
-  ["Bolivian Boliviano", "$b", "BOB", 0],
 ];
 
 export const nonUsdCurrencies = data.map(


### PR DESCRIPTION
New indexing flow:

- Blocks available in `latest` = data available in `eth_transfers`, `erc20_transfers`, and `erc4337_user_op`
- ShovelSquared tracks this, updates `blocks`, `daimo_transfers`, `daimo_ops` and finally `daimo_index`
- Watcher tracks blocks available in `daimo_index`, updates in-memory index