### PR TITLE
mobile: show invite link on QR page

### DIFF
--- a/apps/daimo-mobile/src/view/screen/QRScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/QRScreen.tsx
@@ -77,7 +77,14 @@ function QRDisplay() {
   const nav = useNav();
   if (account == null) return null;
 
-  const url = formatDaimoLink({ type: "account", account: account.name });
+  // Show our invite link, if we have one. Otherwise, just link to our account.
+  // Either way, if a user w/ app installed scans, they go to our account page.
+  const { inviteLinkStatus } = account;
+  const url = formatDaimoLink(
+    inviteLinkStatus?.isValid
+      ? inviteLinkStatus.link
+      : { type: "account", account: account.name }
+  );
 
   const subtitle = recentlyCopied
     ? i18.copiedAddress()

--- a/apps/daimo-mobile/src/view/screen/onboarding/LogInButton.tsx
+++ b/apps/daimo-mobile/src/view/screen/onboarding/LogInButton.tsx
@@ -1,5 +1,7 @@
 import {
   SlotType,
+  debugJson,
+  derKeytoContractFriendlyKey,
   findAccountUnusedSlot,
   mnemonicToPublicKey,
   tryOrNull,
@@ -73,10 +75,14 @@ export function LogInFromSeedButton({
 }) {
   // Figure out which slot the mnmemonic (seed phrase) key is in
   const parsedKey = tryOrNull(() => mnemonicToPublicKey(mnemonic));
-  const keySlot = account.accountKeys.find(
-    (k) => k.pubKey === parsedKey?.publicKeyDER
-  )?.slot;
-  console.log(`[ONBOARDING] mnemonic key slot: ${keySlot}`);
+  let keySlot: number | undefined;
+  if (parsedKey?.publicKeyDER != null) {
+    const { publicKeyDER } = parsedKey;
+    const pubKeyStr = debugJson(derKeytoContractFriendlyKey(publicKeyDER));
+    console.log(`[ONBOARDING] mnemonic pubkey: ${publicKeyDER} = ${pubKeyStr}`);
+    keySlot = account.accountKeys.find((k) => k.pubKey === publicKeyDER)?.slot;
+    console.log(`[ONBOARDING] mnemonic key slot: ${keySlot}`);
+  }
 
   // Create a signer--can sign signatures and userop for `account`
   const signer = useMemo(() => {


### PR DESCRIPTION
Show our invite link, if we have one. Otherwise, just link to our account.
Either way, if a user w/ app installed scans, they go to our account page.