### PR TITLE
Fix misc typos

### DIFF
--- a/apps/daimo-mobile/src/logic/daimoContacts.ts
+++ b/apps/daimo-mobile/src/logic/daimoContacts.ts
@@ -139,7 +139,7 @@ export function useContactSearch(
     if (onlyNamedEAccs && !acc.name) continue;
 
     // HACK: ignore transfers to specially labelled addresses like "payment link"
-    // TODO: label transfers by whether occured as part of a send or a different transaction; ignore the latter
+    // TODO: label transfers by whether occurred as part of a send or a different transaction; ignore the latter
     // TODO: show note claimer as recipient.
     if (acc.label != null) continue;
 

--- a/apps/daimo-mobile/src/view/screen/DepositScreen.tsx
+++ b/apps/daimo-mobile/src/view/screen/DepositScreen.tsx
@@ -150,7 +150,7 @@ function LandlineAccountList() {
 // An on-demand exchange is one that requires fetching a URL at the time of
 // user's interaction, rather than have it pre-fetched. These exchanges are
 // first fetched with a loading spinner, then the URL is opened.
-// Binance is the only on-demand exchange for now becuase generated links
+// Binance is the only on-demand exchange for now because generated links
 // expire quickly and 301 redirects don't work for opening universal links
 // in Binance app, so we can't include it in the recommendedExchanges API-side.
 function getOnDemandExchanges(

--- a/packages/contract/test/AccountFactory.t.sol
+++ b/packages/contract/test/AccountFactory.t.sol
@@ -33,7 +33,7 @@ contract AccountFactoryTest is Test {
         assertEq(acc.numActiveKeys(), uint8(1));
 
         // deploy again = just returns the existing address
-        // prefund still goes thru to the entrypoint contract
+        // prefund still goes through to the entrypoint contract
         assertEq(entryPoint.getDepositInfo(address(acc)).deposit, 0);
         DaimoAccount acc2 = factory.createAccount{value: 9}(0, key1, calls, 42);
         assertEq(address(acc), address(acc2));

--- a/packages/daimo-api/src/api/getAccountHistory.ts
+++ b/packages/daimo-api/src/api/getAccountHistory.ts
@@ -285,7 +285,7 @@ function getSuggestedActions(
     });
   }
 
-  // Active account: has recieved transfer from another user in "recent"
+  // Active account: has received transfer from another user in "recent"
   // transfer logs. The recency condition means that it will be dismissed
   // automatically if transferLogs are empty (eg, user leaves app open for
   // a while).

--- a/packages/daimo-api/src/api/search.ts
+++ b/packages/daimo-api/src/api/search.ts
@@ -17,9 +17,9 @@ export async function search(
   prefix = prefix.trim();
   if (prefix.startsWith("@")) prefix = prefix.slice(1);
 
-  // Show a santized, simplified view of what the user entered
+  // Show a sanitized, simplified view of what the user entered
   // This is important when eg entering an address > matches reverse ENS
-  // Othewise, you have no confirmation on send screen that it's the same addr.
+  // Otherwise, you have no confirmation on send screen that it's the same addr.
   // Also important when entering an ENS > get a *different* reverse ENS.
 
   let ret: EAccountSearchResult[];

--- a/packages/daimo-api/src/contract/indexer.ts
+++ b/packages/daimo-api/src/contract/indexer.ts
@@ -36,11 +36,11 @@ export abstract class Indexer {
   ): void | Promise<void>;
 
   // Checks whether we just completed a stale query. True = don't process.
-  // Otherwise, returns false (coninue processing) and updates lastProcessedBlock.
+  // Otherwise, returns false (continue processing) and updates lastProcessedBlock.
   protected updateLastProcessedCheckStale(from: number, to: number) {
     if (this.lastProcessedBlock >= from) {
       console.warn(
-        `[${this.name}] SKIPPING ${from}-${to}, already processed thru ${this.lastProcessedBlock}`
+        `[${this.name}] SKIPPING ${from}-${to}, already processed through ${this.lastProcessedBlock}`
       );
       return true;
     }

--- a/packages/daimo-api/src/network/viemClient.ts
+++ b/packages/daimo-api/src/network/viemClient.ts
@@ -113,7 +113,7 @@ export function getEOA(privateKey: string) {
 }
 
 /**
- * All access to the chain goes thru this client. A ViemClient lets you read L1,
+ * All access to the chain goes through this client. A ViemClient lets you read L1,
  * read L2, and post transactions to L2.
  */
 export class ViemClient {

--- a/packages/daimo-api/src/shovel/watcher.ts
+++ b/packages/daimo-api/src/shovel/watcher.ts
@@ -40,7 +40,7 @@ export class Watcher {
   private batchSize = 1000_000;
   private isIndexing = false;
 
-  // The latest block thru which our DB index is up to date.
+  // The latest block through which our DB index is up to date.
   private indexLatest = 0;
   // The latest block as reported directly by the RPC (not shovel)
   private rpcLatest = 0;

--- a/packages/daimo-api/src/utils/cache.ts
+++ b/packages/daimo-api/src/utils/cache.ts
@@ -3,7 +3,7 @@ import { assert } from "@daimo/common";
 /**
  * Lazily executes `fn` and caches the result ensuring only one execution at a time.
  *
- * `cacheTime` is duration in ms after cached value is considred expired,
+ * `cacheTime` is duration in ms after cached value is considered expired,
  * and must be refreshed before it can be returned.
  *
  * `staleTime` is an optional duration that refreshes

--- a/packages/daimo-common/src/op.ts
+++ b/packages/daimo-common/src/op.ts
@@ -64,7 +64,7 @@ export type PostSwapTransfer = {
  * There's a surprising amount of complexity to the state of a transfer.
  *
  * - Daimo transfers start out as a `PENDING` user op.
- *   The op goes thru a lifecycle of pending (bundler has accepted, but not
+ *   The op goes through a lifecycle of pending (bundler has accepted, but not
  *   yet onchain) to confirmed (bundle transaction onchain) to finalized
  *   (written to a finalized L1 block, and therefore guaranteed permanent).
  *

--- a/packages/daimo-expo-enclave/README.md
+++ b/packages/daimo-expo-enclave/README.md
@@ -12,7 +12,7 @@ Depending on where the keys are stored and processed for signatures and other op
 
 1. Software only: Weakest, only a weak software abstraction to isolate access to the key data, can be broken by kernel attacks and such. Kinda similar in security level to normal iOS/macOS Keychain (encrypted) keys.
 2. TEE: Medium, secure "area" of processor/OS with a lot of shared surface with main OS. Generally runs its own software and communicates with "main" OS via some restricted interface. OS compromises should usually not break security, but kernel exploits might, and these are not resistant to side channel attacks and such. Kinda like a poor man's secure enclave.
-3. StrongBox: Strongest, entirely seperate chip with its own RAM, CPU etc., usually require at least firmware level attacks to break security. Equivalent to Apple's Secure Enclaves.
+3. StrongBox: Strongest, entirely separate chip with its own RAM, CPU etc., usually require at least firmware level attacks to break security. Equivalent to Apple's Secure Enclaves.
 
 In reality, this API is not exactly reflective of the ground truth as device manufacturers are liberal with their definition of each one and not particularly intellectually honest, but we ignore those concerns and trust what the API believes the security level is is reflective of the hardware ground truth.
 

--- a/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
+++ b/packages/daimo-expo-enclave/ios/SecureEnclaveKeyManager.swift
@@ -52,7 +52,7 @@ public class SecureEnclaveKeyManager : KeyManager {
         
         // Since the key is authed by the enclave and the keychain only stores an encrypted blob
         // representation, we do not auth userPresence for keychain reads. Additionally, it would
-        // be bad UX to prompt the user for presence/auth twice (seperately for keychain reads and
+        // be bad UX to prompt the user for presence/auth twice (separately for keychain reads and
         // on Secure Enclave signing).
         try self.store.storeKey(signingPrivkey, account: accountName, requireUserPresence: false)
     }

--- a/packages/daimo-expo-passkeys/ios/AuthResponder.swift
+++ b/packages/daimo-expo-passkeys/ios/AuthResponder.swift
@@ -5,7 +5,7 @@
 //  Created by Nalin Bhardwaj.
 //  Copyright © 2023 Daimo. All rights reserved.
 //
-//  AuthResponder is the delegate that recieves the result of a Passkey or 
+//  AuthResponder is the delegate that receives the result of a Passkey or 
 //  SecurityKey creation/sign request and passes it back to the callback 
 //  for processing.
 


### PR DESCRIPTION
Includes writing 'thru' as 'through'.

All changes are non-functional in comments or READMEs and should have no effect on the app, just helps maintain the code base.

This is easiest to review with command `git show --word-diff` if pulling locally.