### PR TITLE
mobile: handle tag deeplinks during onboarding

### DIFF
--- a/apps/daimo-mobile/src/common/nav.ts
+++ b/apps/daimo-mobile/src/common/nav.ts
@@ -1,6 +1,5 @@
 import {
   DAv2Chain,
-  DaimoInviteCodeStatus,
   DaimoLink,
   DaimoLinkAccount,
   DaimoLinkInviteCode,
@@ -14,6 +13,7 @@ import {
   TransferClog,
   getEAccountStr,
   parseDaimoLink,
+  parseInviteCodeOrLink,
 } from "@daimo/common";
 import { DaimoChain, daimoChainFromId } from "@daimo/contract";
 import { NavigatorScreenParams, useNavigation } from "@react-navigation/native";
@@ -34,7 +34,7 @@ import {
   getInitialDeepLink,
   markInitialDeepLinkHandled,
 } from "../logic/deeplink";
-import { fetchLinkStatus } from "../logic/linkStatus";
+import { fetchInviteLinkStatus, fetchLinkStatus } from "../logic/linkStatus";
 import { MoneyEntry } from "../logic/moneyEntry";
 import { Account } from "../storage/account";
 
@@ -215,43 +215,21 @@ export async function handleOnboardingDeepLink(
   str: string
 ) {
   console.log(`[INTRO] paste invite link: '${str}'`);
-
-  const link = parseDaimoLink(str);
-  if (link == null) {
-    console.log(`[INTRO] skipping unparseable link ${str}`);
+  const inviteLink = parseInviteCodeOrLink(str);
+  if (!inviteLink) {
+    console.log(`[INTRO] skipping unparseable invite link/code ${str}`);
     nav.navigate("CreateNew");
     return;
   }
-  if (link.type !== "invite" && link.type !== "tag") {
-    console.log(`[INTRO] skipping non-onboarding deep link ${str}`);
-    nav.navigate("CreateNew");
-    return;
-  }
+  console.log(`[INTRO] parsed invite link: ${JSON.stringify(inviteLink)}`);
 
-  const linkStatus = await fetchLinkStatus(link, dc);
-  if (linkStatus.link.type !== "invite") {
-    console.log(
-      `[INTRO] got link status of non-invite link ${str}. status: ${JSON.stringify(
-        linkStatus.link
-      )} is not an invite link`
-    );
-    nav.navigate("CreateNew");
-    return;
-  }
-
-  const inviteStatus = linkStatus as DaimoInviteCodeStatus;
+  const linkStatus = await fetchInviteLinkStatus(dc, inviteLink);
   const isAndroid = Platform.OS === "android";
-  if (inviteStatus.isValid) {
-    console.log(
-      `[INTRO] onboarding with invite code: ${inviteStatus.link.code}`
-    );
-    if (isAndroid)
-      nav.navigate("CreateSetupKey", { inviteLink: inviteStatus.link });
-    else nav.navigate("CreateChooseName", { inviteLink: inviteStatus.link });
+  if (linkStatus?.isValid) {
+    if (isAndroid) nav.navigate("CreateSetupKey", { inviteLink });
+    else nav.navigate("CreateChooseName", { inviteLink });
   } else {
-    console.log(
-      `[INTRO] invite code is no longer valid. code: ${inviteStatus.link.code}`
-    );
+    console.log(`[INTRO] invite ${str} is no longer valid.`);
     nav.navigate("CreateNew");
   }
 }

--- a/apps/daimo-mobile/src/logic/linkStatus.ts
+++ b/apps/daimo-mobile/src/logic/linkStatus.ts
@@ -3,6 +3,7 @@ import {
   DaimoLinkStatus,
   formatDaimoLink,
   getInviteStatus,
+  LinkInviteStatus,
   stripSeedFromNoteLink,
 } from "@daimo/common";
 import { DaimoChain } from "@daimo/contract";
@@ -32,10 +33,12 @@ export async function fetchLinkStatus(
 export async function fetchInviteLinkStatus(
   daimoChain: DaimoChain,
   inviteLink: DaimoLink | undefined
-) {
+): Promise<LinkInviteStatus | undefined> {
+  if (!inviteLink) return undefined;
+
   const rpcFunc = getRpcFunc(daimoChain);
-  const url = inviteLink && formatDaimoLink(stripSeedFromNoteLink(inviteLink));
-  const linkStatus = !!url && (await rpcFunc.getLinkStatus.query({ url }));
-  const inviteStatus = linkStatus ? getInviteStatus(linkStatus) : undefined;
+  const url = formatDaimoLink(stripSeedFromNoteLink(inviteLink));
+  const linkStatus = await rpcFunc.getLinkStatus.query({ url });
+  const inviteStatus = getInviteStatus(linkStatus);
   return inviteStatus;
 }

--- a/packages/daimo-common/src/invite.ts
+++ b/packages/daimo-common/src/invite.ts
@@ -21,11 +21,7 @@ export function parseInviteCodeOrLink(str: string): DaimoLink | undefined {
 
   // Is it a link?
   const link = parseDaimoLink(str);
-  if (link != null && ["invite", "requestv2", "notev2"].includes(link.type)) {
-    return link;
-  }
-
-  return undefined;
+  return link || undefined;
 }
 
 export interface LinkInviteStatus {


### PR DESCRIPTION
When clicking a tag deeplink that redirects to an invite link, it doesn't autofill the invite code.

Messed up and didn't notice this issue in this PR :(
https://github.com/daimo-eth/daimo/pull/1276

## Testing
Created an invite code called `test` and a tag called `test` which redirects to `https://daimo.com/l/invite/test`.
Created an invalid invite code called `test` and a tag called `test1`.
Created a tag called `request` which redirects to `https://daimo.com/l/request?to=vitalik.eth&c=84532&t=usdc`

| link       | result       |
|----------------|----------------|
| daimo://t/test | redirects to "choose username"  |
| daimo://invite/test  | redirects to "choose username"  |
| daimo://t/test1  | redirects to "enter invite code" |
| daimo://invite/test1  | redirects to "enter invite code" |
| daimo://t/request  | redirects to "enter invite code" |
| daimo://request?to=vitalik.eth&c=84532&t=usdc  | redirects to "enter invite code" |