### PR TITLE
Fixed Months in timelime in app

### DIFF
--- a/apps/daimo-mobile/src/i18n/languages/es.ts
+++ b/apps/daimo-mobile/src/i18n/languages/es.ts
@@ -158,7 +158,7 @@ export const es: LanguageDefinition = {
   // NotificationsScreen.tsx
   notifications: {
     screenHeader: () => `Notificaciones`,
-    noNotifications: () => `No notificaciones`,
+    noNotifications: () => `Ninguna notificación`,
   },
   // RequestNotificationRow.tsx
   requestNotification: {

--- a/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
+++ b/apps/daimo-mobile/src/view/screen/history/HistoryList.tsx
@@ -118,11 +118,15 @@ export function HistoryListSwipe({
   // Full case: show a scrollable, lazy-loaded FlatList
   const stickyIndices = [] as number[];
   const rows: (transferClogRenderObject | HeaderObject)[] = [];
+  let language = i18NLocale.languageCode;
+
+  // if null, set to english
+  language ??= "en";
 
   // Render a HeaderRow for each month, and make it sticky
   let lastMonth = "";
   for (const op of ops) {
-    const month = new Date(op.timestamp * 1000).toLocaleString("default", {
+    const month = new Date(op.timestamp * 1000).toLocaleString(language, {
       year: "numeric",
       month: "long",
     });


### PR DESCRIPTION
Now in HistoryList inside the daimo app, the Months can be in multiple languages.

Made a small change inside `view/screen/history/HistoryList.tsx`, it retrives the locale, sets it to 'default' if null, then we use it inside `toLocaleString(language)` in line 129.

Encountered small problem with Spanish, it returned the first letter of the month in lowercase, added code to ensure the first letter of the month is in uppercase.

- first draft
- fix Months in HistoryList
