### PR TITLE
indexer: start from beginning on testnet

### DIFF
--- a/packages/daimo-api/src/db/indexWatcher.ts
+++ b/packages/daimo-api/src/db/indexWatcher.ts
@@ -1,8 +1,4 @@
-import {
-  guessTimestampFromNum,
-  now,
-  retryBackoff,
-} from "@daimo/common";
+import { guessTimestampFromNum, now, retryBackoff } from "@daimo/common";
 import { Kysely, PostgresDialect } from "kysely";
 import { ClientConfig, Pool, PoolConfig } from "pg";
 import { PublicClient } from "viem";

--- a/packages/daimo-api/src/db/indexWatcher.ts
+++ b/packages/daimo-api/src/db/indexWatcher.ts
@@ -62,9 +62,7 @@ export class IndexWatcher {
     });
     this.notifications = new DBNotifier(dbConfig);
 
-    const { testnet } = assertNotNull(rpcClient.chain);
-    if (testnet) this.latest = 12000000 - 1;
-    else this.latest = 5700000 - 1;
+    this.latest = 5700000 - 1;
   }
 
   add(...i: Indexer[][]) {

--- a/packages/daimo-api/src/db/indexWatcher.ts
+++ b/packages/daimo-api/src/db/indexWatcher.ts
@@ -1,5 +1,4 @@
 import {
-  assertNotNull,
   guessTimestampFromNum,
   now,
   retryBackoff,


### PR DESCRIPTION
Fixes https://github.com/daimo-eth/daimo/issues/1319

Issue where name says "available" on testnet even though it's not. This is because our testnet indexer loads from a later block than when NameReg started. the earliest name registered on testnet is on block `5893972`. Both testnet and mainnet start from `5700000` for simplicity. 

Now says `name is unavailable`:

<img width="346" alt="Screenshot 2024-09-10 at 4 10 39 PM" src="https://github.com/user-attachments/assets/eb497bef-9af7-4114-88d3-f627b08f3a40">
