### PR TITLE
release: 1.9.10

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -4,7 +4,7 @@ const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
 // Next pending release version. Update this only as part of a release PR.
 // For example, PR "release: 1.2.3" = checklist + update below to 1.2.4.
-const VERSION = "1.9.10";
+const VERSION = "1.9.11";
 
 const config: ExpoConfig = {
   owner: "daimo",

--- a/apps/daimo-mobile/src/common/nav.ts
+++ b/apps/daimo-mobile/src/common/nav.ts
@@ -132,6 +132,7 @@ export interface SendNavProp {
   memo?: string;
   requestId?: `${bigint}`;
   autoFocus?: boolean;
+  edit?: "money" | "memo" | "coin";
 }
 
 export interface LandlineTransferNavProp {

--- a/apps/daimo-mobile/src/common/nav.ts
+++ b/apps/daimo-mobile/src/common/nav.ts
@@ -13,12 +13,7 @@ import {
   parseDaimoLink,
   parseInviteCodeOrLink,
 } from "@daimo/common";
-import {
-  DAv2Chain,
-  DaimoChain,
-  ForeignToken,
-  daimoChainFromId,
-} from "@daimo/contract";
+import { DaimoChain, ForeignToken, daimoChainFromId } from "@daimo/contract";
 import { NavigatorScreenParams, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { URLListener, addEventListener } from "expo-linking";
@@ -134,7 +129,6 @@ export interface SendNavProp {
   recipient?: EAccountContact;
   money?: MoneyEntry;
   toCoin?: ForeignToken;
-  toChain?: DAv2Chain;
   memo?: string;
   requestId?: `${bigint}`;
   autoFocus?: boolean;

--- a/apps/daimo-mobile/src/i18n/languages/en.ts
+++ b/apps/daimo-mobile/src/i18n/languages/en.ts
@@ -548,7 +548,7 @@ export const en = {
   // HomeScreen.tsx
   home: {
     pending: (pendingDollars: string) => `+ $${pendingDollars} PENDING`,
-    finishAccountSetUp: () => `Finish setting up your account`,
+    finishAccountSetUp: () => `Secure your account`,
     yourBalance: () => `Your balance`,
     deposit: () => `Deposit`,
     request: () => `Request`,

--- a/apps/daimo-mobile/src/view/screen/LandlineBankTransfer.tsx
+++ b/apps/daimo-mobile/src/view/screen/LandlineBankTransfer.tsx
@@ -1,4 +1,4 @@
-import { base, baseUSDC, DaimoChain, daimoChainFromId } from "@daimo/contract";
+import { baseUSDC, DaimoChain, daimoChainFromId } from "@daimo/contract";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ReactNode, useCallback, useState } from "react";
 import {
@@ -248,7 +248,6 @@ function SendConfirm({
   bankTransferOption: BankTransferOptions;
 }) {
   const nav = useNav();
-
   const navToInput = () => {
     nav.navigate("DepositTab", {
       screen: "LandlineTransfer",
@@ -275,7 +274,6 @@ function SendConfirm({
         // https://apidocs.bridge.xyz/docs/liquidation-address
         minTransferAmount={1.0}
         toCoin={baseUSDC} // TODO: get home coin from account
-        toChain={base} // TODO: get home chain from account
       />
     ) : (
       <LandlineDepositButton

--- a/apps/daimo-mobile/src/view/screen/send/CoinDisplay.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/CoinDisplay.tsx
@@ -155,13 +155,12 @@ function CoinPickItem({
 
 export function CoinPellet({
   toCoin,
-  toChain,
   onClick,
 }: {
   toCoin: ForeignToken;
-  toChain: DAv2Chain;
   onClick: () => void;
 }) {
+  const toChain = getDAv2Chain(toCoin.chainId);
   const chainUri = getChainUri(toChain);
   return (
     <View style={{ ...styles.coinButton, backgroundColor: color.white }}>

--- a/apps/daimo-mobile/src/view/screen/send/CoinDisplay.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/CoinDisplay.tsx
@@ -13,6 +13,7 @@ import {
   polygon,
   polygonAmoy,
 } from "@daimo/contract";
+import { useEffect, useRef } from "react";
 import {
   Image,
   ImageSourcePropType,
@@ -54,11 +55,20 @@ const getChainUri = (chain: DAv2Chain) => {
 export function SendCoinButton({
   toCoin,
   setCoin,
+  autoFocus,
 }: {
   toCoin: ForeignToken;
   setCoin: (coin: ForeignToken) => void;
+  autoFocus?: boolean;
 }) {
   const account = useAccount();
+
+  // Autofocus
+  const ddRef = useRef<SelectDropdown>(null);
+  useEffect(() => {
+    if (autoFocus && ddRef.current) ddRef.current.openDropdown();
+  }, []);
+
   if (account == null) return null;
 
   // Get home coin = default send coin + all other supported send coins
@@ -79,6 +89,7 @@ export function SendCoinButton({
       data={supportedSendPairs}
       defaultValue={homeCoin}
       onSelect={onSetPair}
+      ref={ddRef}
       renderButton={() => (
         <View style={{ ...styles.coinButton, backgroundColor: color.white }}>
           <View style={styles.coinPickerWrap}>

--- a/apps/daimo-mobile/src/view/screen/send/MemoDisplay.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/MemoDisplay.tsx
@@ -14,12 +14,14 @@ export function SendMemoButton({
   memo,
   memoStatus,
   setMemo,
+  autoFocus,
 }: {
   memo: string | undefined;
   memoStatus: "ok" | string | undefined;
   setMemo: (memo: string | undefined) => void;
+  autoFocus?: boolean;
 }) {
-  const [isFocused, setIsFocused] = useState(false);
+  const [isFocused, setIsFocused] = useState(autoFocus || false);
 
   const ref = useRef<TextInput>(null);
 

--- a/apps/daimo-mobile/src/view/screen/send/RouteDisplay.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/RouteDisplay.tsx
@@ -3,7 +3,11 @@ import {
   amountToDollars,
   getForeignCoinDisplayAmount,
 } from "@daimo/common";
-import { DAv2Chain, ForeignToken, getChainDisplayName } from "@daimo/contract";
+import {
+  ForeignToken,
+  getChainDisplayName,
+  getDAv2Chain,
+} from "@daimo/contract";
 import { StyleSheet, View } from "react-native";
 
 import { i18n } from "../../../i18n";
@@ -15,13 +19,11 @@ export function RoutePellet({
   route,
   fromCoin,
   fromAmount,
-  toChain,
   toCoin,
 }: {
   route: ProposedSwap | null;
   fromCoin: ForeignToken;
   fromAmount: bigint;
-  toChain: DAv2Chain;
   toCoin: ForeignToken;
 }) {
   let toAmountStr: string;
@@ -34,6 +36,7 @@ export function RoutePellet({
     toAmountStr = getForeignCoinDisplayAmount(BigInt(route.toAmount), toCoin);
   }
 
+  const toChain = getDAv2Chain(toCoin.chainId);
   const chainName = getChainDisplayName(toChain);
 
   return (

--- a/apps/daimo-mobile/src/view/shared/AmountInput.tsx
+++ b/apps/daimo-mobile/src/view/shared/AmountInput.tsx
@@ -75,7 +75,7 @@ export function AmountChooser({
       <View style={{ flexDirection: "row", justifyContent: "center" }}>
         {isNonUSD && (
           <Badge color={color.midnight}>
-            = ${moneyEntry.dollars.toFixed(2)} {toCoin?.symbol ?? "USDC"}
+            = ${moneyEntry.dollars.toFixed(2)}
           </Badge>
         )}
         {showAmountAvailable && !isNonUSD && (
@@ -173,8 +173,6 @@ function AmountInput({
   }, [ref, onFocus]);
 
   // Currency picker
-  // const [currency, onSetCurrency] =
-  //   useState<CurrencyExchangeRate>(currencyRateUSD);
   const account = useAccount();
   const allCurrencies = [currencyRateUSD, ...(account?.exchangeRates || [])];
   const onSetCurrency = (currency: CurrencyExchangeRate) => {

--- a/apps/daimo-mobile/src/view/sheet/BitrefillBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/BitrefillBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { DollarStr } from "@daimo/common";
-import { polygon, polygonUSDC } from "@daimo/contract";
+import { polygonUSDC } from "@daimo/contract";
 import { useState } from "react";
 import { View } from "react-native";
 import { Address } from "viem";
@@ -45,7 +45,6 @@ function BitrefillBottomSheetInner({
 
   const money = usdEntry(amount);
   const toCoin = polygonUSDC;
-  const toChain = polygon;
 
   const [success, setSuccess] = useState(false);
 
@@ -68,7 +67,7 @@ function BitrefillBottomSheetInner({
         onFocus={() => {}}
       />
       <Spacer h={16} />
-      <CoinPellet toCoin={toCoin} toChain={toChain} onClick={() => {}} />
+      <CoinPellet toCoin={toCoin} onClick={() => {}} />
       <Spacer h={24} />
       <SendTransferButton
         account={account}
@@ -76,7 +75,6 @@ function BitrefillBottomSheetInner({
         recipient={recipient}
         dollars={money.dollars}
         toCoin={toCoin}
-        toChain={toChain}
         onSuccess={() => {
           setSuccess(true);
         }}

--- a/apps/daimo-mobile/src/view/sheet/BitrefillBottomSheet.tsx
+++ b/apps/daimo-mobile/src/view/sheet/BitrefillBottomSheet.tsx
@@ -37,11 +37,9 @@ function BitrefillBottomSheetInner({
   address: Address;
   amount: `${number}`;
 }) {
-  const recipient: EAccountContact = {
-    type: "eAcc",
-    addr: address,
-    name: "Bitrefill",
-  };
+  const recipient: EAccountContact = { type: "eAcc", addr: address };
+  // Show "bitrefill" as the name, but only on the send screen
+  const recipientWithName = { ...recipient, name: "Bitrefill" };
 
   const money = usdEntry(amount);
   const toCoin = polygonUSDC;
@@ -52,7 +50,7 @@ function BitrefillBottomSheetInner({
     <View>
       <Spacer h={24} />
       <ContactDisplay
-        contact={recipient}
+        contact={recipientWithName}
         isRequest={false}
         onPress={() => {}}
       />
@@ -75,9 +73,7 @@ function BitrefillBottomSheetInner({
         recipient={recipient}
         dollars={money.dollars}
         toCoin={toCoin}
-        onSuccess={() => {
-          setSuccess(true);
-        }}
+        onSuccess={() => setSuccess(true)}
       />
       {success && (
         <IconRow

--- a/apps/daimo-mobile/test/nav.test.ts
+++ b/apps/daimo-mobile/test/nav.test.ts
@@ -1,5 +1,5 @@
 import { DaimoLink } from "@daimo/common";
-import { base, baseUSDC } from "@daimo/contract";
+import { baseUSDC } from "@daimo/contract";
 
 import { Dispatcher } from "../src/action/dispatch";
 import { MainNav, handleDeepLink } from "../src/common/nav";
@@ -47,7 +47,6 @@ describe("nav", () => {
         dollars: "1.23",
         requestId: "456",
         toCoin: baseUSDC,
-        toChain: base,
       },
     });
   });

--- a/packages/daimo-common/src/eAccount.ts
+++ b/packages/daimo-common/src/eAccount.ts
@@ -59,11 +59,20 @@ export function canSendTo(acc: EAccount): boolean {
   // Daimo accounts, ENS & bare addresses can receive funds.
   if (acc.label == null) return true;
   // Certain labelled accounts cannot.
-  return ![
-    AddrLabel.PaymentLink,
-    AddrLabel.Paymaster,
-    AddrLabel.FastCCTP,
-  ].includes(acc.label);
+  switch (acc.label) {
+    case AddrLabel.PaymentLink:
+    case AddrLabel.Paymaster:
+    case AddrLabel.FastCCTP:
+    case AddrLabel.Coinbase:
+    case AddrLabel.Binance:
+    case AddrLabel.LiFi:
+    case AddrLabel.Relay:
+    case AddrLabel.RequestLink:
+    case AddrLabel.UniswapETHPool:
+      return false;
+    case AddrLabel.Faucet:
+      return true;
+  }
 }
 
 export function canRequestFrom(acc: EAccount): boolean {

--- a/packages/daimo-common/test/daimoLink.test.ts
+++ b/packages/daimo-common/test/daimoLink.test.ts
@@ -1,12 +1,4 @@
-import {
-  base,
-  baseETH,
-  baseUSDC,
-  optimism,
-  optimismUSDC,
-  polygon,
-  polygonUSDC,
-} from "@daimo/contract";
+import { baseETH, baseUSDC, optimismUSDC, polygonUSDC } from "@daimo/contract";
 import assert from "node:assert";
 import test from "node:test";
 
@@ -44,7 +36,6 @@ const testCases: [string, DaimoLink | null][] = [
       dollars: "1.23",
       requestId: "123",
       toCoin: baseUSDC,
-      toChain: base,
     },
   ],
   [
@@ -55,7 +46,6 @@ const testCases: [string, DaimoLink | null][] = [
       dollars: "4.20",
       requestId: "555",
       toCoin: baseUSDC,
-      toChain: base,
     },
   ],
   [
@@ -221,7 +211,6 @@ test("Old DaimoLinkRequest parsing", () => {
         dollars: "1.23",
         requestId: "123",
         toCoin: baseUSDC,
-        toChain: base,
       },
     ],
     [
@@ -232,7 +221,6 @@ test("Old DaimoLinkRequest parsing", () => {
         dollars: "4.20",
         requestId: "555",
         toCoin: baseUSDC,
-        toChain: base,
       },
     ],
     ["https://daimo.com/l/request?to=0x0", null],
@@ -266,7 +254,6 @@ test("New DaimoLinkRequest parsing", () => {
       {
         type: "request",
         recipient: "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93",
-        toChain: optimism,
         toCoin: optimismUSDC,
         requestId: "123",
       },
@@ -277,7 +264,6 @@ test("New DaimoLinkRequest parsing", () => {
       {
         type: "request",
         recipient: "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93",
-        toChain: optimism,
         toCoin: optimismUSDC,
         dollars: "1.23",
       },
@@ -288,7 +274,6 @@ test("New DaimoLinkRequest parsing", () => {
       {
         type: "request",
         recipient: "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93",
-        toChain: polygon,
         toCoin: polygonUSDC,
         dollars: "1.23",
       },
@@ -299,7 +284,6 @@ test("New DaimoLinkRequest parsing", () => {
       {
         type: "request",
         recipient: "0x061b0a794945fe0Ff4b764bfB926317f3cFc8b93",
-        toChain: base,
         toCoin: baseETH,
         dollars: "1.23",
       },


### PR DESCRIPTION
**Option to send ETH.**

## Release checklist

### Production (mainnet) smoke test

#### Deploy prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean

#### iOS

- [x] Install from private TestFlight
- [x] Log into your prod account
- [x] Send a transfer
- [x] Notification appears on confirmation

#### Android

- [x] Install from private TestFlight
- [x] Log into your prod account
- [x] Send a transfer
- [x] Notification appears on confirmation

#### Either platform

- [x] Log out + create new account
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.
- [x] Send to USDC Arbitrum
- [x] Receive Base ETH, test inbox claim. **Issue, see #1082**

### Cross-chain + memo tests

- [x] Send 500 ARS to a .eth on Optimism, with a memo. Transfer should show "500 ARS · USDC Op · hello world" + the .eth final destination.
- [x] Send a few cents to each other supported chain. Verify ~immediate receipt.
- [x] Create a 0.20 EUR payment link ~with memo~. Claim in another account. Currency + memo shows up on both ends. **When link has a currency only, does not appear as memo.**  https://github.com/daimo-eth/daimo/issues/1328
- [x] Create a 0.20 GBP request link. Ensure currency + memo appears in webapp + in both sender & receiver app.
- [x] **Send Vitalik $0.20 worth of ETH:** https://daimo.com/l/request?to=vitalik.eth&n=0.20&c=8453&t=eth
- [x] **Send $0.10 of USDC on Optimism:** https://daimo.com/l/request?to=vitalik.eth&n=0.10&c=10&t=usdc

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
