### PR TITLE
release: 1.9.11

### DIFF
--- a/apps/daimo-mobile/app.config.ts
+++ b/apps/daimo-mobile/app.config.ts
@@ -4,7 +4,7 @@ const IS_DEV = process.env.DAIMO_APP_VARIANT === "dev";
 
 // Next pending release version. Update this only as part of a release PR.
 // For example, PR "release: 1.2.3" = checklist + update below to 1.2.4.
-const VERSION = "1.9.11";
+const VERSION = "1.9.12";
 
 const config: ExpoConfig = {
   owner: "daimo",


### PR DESCRIPTION
**Better deposits and cross-chain sends.**

* Lets us ship Landline

## Release checklist

### Production (mainnet) smoke test

#### Deploy prod

- [x] Push to `prod`
- [x] Prod API deploys correctly
- [x] Prod website deploys correctly
- [x] Logs clean

#### iOS

- [x] Install from private TestFlight
- [x] Log into your prod account
- [x] Send a transfer
- [x] Notification appears on confirmation

#### Android

- [x] Install from private TestFlight
- [x] Log into your prod account
- [x] Send a transfer
- [x] Notification appears on confirmation (Andrew: notification appeared on my desktop app but not mobile, DC: works for me)
- [x] **Font fix: #1345**
- [x] cross-chain send works

#### Either platform

- [x] Log out + create new account
- [x] Create Payment Link, open in browser.
- [x] Reclaim link. Refresh page in browser, ensure status shows correctly.
- [x] Tap link. Ensure opens in app, status shows correctly.
- [x] Send to USDC Arbitrum
- [x] Fulfill "deposit ETH" request link
- [x] ~Receive Base ETH, test inbox claim.~ **ETH indexer issue, requires backfill.**

### Account management

- [x] Create new account using an invite link
- [x] Add a passkey, log out + back in using passkey
- [x] ~Add a security key, log out + back in with Yubikey.~ **Did iOS 18 added PIN requirement (?!)**
- [x] Add a seed phrase, log out + back in with seed phrase

### Cross-chain + memo tests

- [x] Send 500 ARS to a .eth on Optimism, with a memo. Transfer should show 500 ARS, USDC Op, hello world + the .eth final destination.
- [x] Send a few cents to each other supported chain. Verify ~immediate receipt.
- [x] ~Create a 0.20 EUR payment link with memo. Claim in another account. Currency + memo shows up on both ends.~ **See https://github.com/daimo-eth/daimo/issues/1328**
- [x] Create a 0.20 GBP request link. Ensure currency + memo appears in webapp + in both sender & receiver app.

**Request memos don't appear correctly on web. Fixed here: https://github.com/daimo-eth/daimo/pull/1344**

### Promote release

BEFORE merging this PR,

- [x] Push to App Store + Play Store, INCLUDING TestFlight + Open test track.
- [x] Bump version number for next development cycle.

Production mainnet releases will eventually trail TestFlight by at least a week
to allow longer and more thorough testing.
