### PR TITLE
mobile: fix cross-chain check

### DIFF
--- a/apps/daimo-mobile/src/view/screen/send/SendTransferButton.tsx
+++ b/apps/daimo-mobile/src/view/screen/send/SendTransferButton.tsx
@@ -71,7 +71,8 @@ export function SendTransferButton({
   // Note whether the transfer has a swap or not for op creation.
   const homeCoin = getHomeCoin(account);
   const isBridge = toCoin.chainId !== homeCoin.chainId;
-  const isSwap = homeCoin.token !== toCoin.token;
+  const toChain = getDAv2Chain(toCoin.chainId);
+  const isSwap = toChain.bridgeCoin.token !== toCoin.token;
   // TODO: handle case with swap and bridge
   assert(!(isSwap && isBridge), "swap+bridge unsupported");
 


### PR DESCRIPTION
Fixes the `isSwap` check for asserting the transfer is not a bridge+swap. 

Tokens have different addresses on different chains (e.g. Base USDC token addr != Arb USDC token addr), so must instead check that the `toCoin` address is not the same as the `bridgeCoin` for the `toChain` to check whether it's a swap