### PR TITLE
pay common & contract v1.3.4: improve payment option filtering

### DIFF
--- a/packages/daimo-common/package.json
+++ b/packages/daimo-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daimo/common",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "description": "Daimo shared models and utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,7 +24,7 @@
     "typescript": "5.5.2"
   },
   "dependencies": {
-    "@daimo/contract": "1.3.1",
+    "@daimo/contract": "1.3.4",
     "@noble/curves": "^1.6.0",
     "@scure/base": "^1.1.9",
     "@scure/bip39": "^1.3.0",

--- a/packages/daimo-common/src/daimoPay.ts
+++ b/packages/daimo-common/src/daimoPay.ts
@@ -135,6 +135,14 @@ export const zDaimoPayOrderMetadata = z.object({
         .describe(
           "Preferred tokens, in descending order. Any preferred assets the user owns will appear first. Defaults to destination token.",
         ),
+      // Filter to only allow payments on these chains. Keep this
+      // parameter undocumented. Only for specific customers.
+      evmChains: z
+        .array(z.number())
+        .optional()
+        .describe(
+          "Filter to only allow payments on these EVM chains. Defaults to all chains.",
+        ),
       paymentOptions: z
         .array(z.string())
         .optional()
@@ -352,6 +360,9 @@ export enum ExternalPaymentOptions {
   Coinbase = "Coinbase",
   RampNetwork = "RampNetwork",
   Binance = "Binance",
+  Solana = "Solana",
+  // ChangeNow chains. Bitcoin, Litecoin, Doge, Tron, etc.
+  ExternalChains = "ExternalChains",
 }
 
 export type ExternalPaymentOptionData = {

--- a/packages/daimo-contract/package.json
+++ b/packages/daimo-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daimo/contract",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "description": "Daimo contracts, ABIs, and generated Typescript types",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
- add `paymentChains` parameter to filter EVM chains
- add solana and external chains to `paymentOptions`