### PR TITLE
chore: fixed broken link

### DIFF
--- a/packages/daimo-api/src/api/getSwapRoute.ts
+++ b/packages/daimo-api/src/api/getSwapRoute.ts
@@ -87,7 +87,7 @@ export async function getSwapQuote({
 
   // By default, the router holds the funds until the last swap, then it is
   // sent to the recipient. Special case: if outputToken is ETH, unwrap first.
-  // Reference: https://github.com/Uniswap/sdks/blob/main/sdks/universal-router-sdk/src/entities/protocols/uniswap.ts
+  // Reference: https://github.com/Uniswap/sdks/blob/main/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
   const swapRecipient: Address = isToETH ? swapRouter02Address : toAddr;
 
   const t = now();


### PR DESCRIPTION
Hi! I replaced an outdated Uniswap SDK link in `getSwapRoute.ts`.  Old reference was pointing to `entities/protocols/uniswap.ts`, which no longer exists — updated to the correct `entities/actions/uniswap.ts`.